### PR TITLE
main: change name of loaded javascript to match generated name

### DIFF
--- a/main/templates/main/main.html
+++ b/main/templates/main/main.html
@@ -3,7 +3,7 @@
     <head>
         <title>Flight Safety System</title>
         <base href="/static/" />
-        <script type="module" src="frontend.js"></script>
+        <script type="module" src="main.js"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>


### PR DESCRIPTION
This fixes: e2573fa frontend: use local bootstrap
which changed frontend.js to main.js