### PR TITLE
frontend: Minor asset server button tidy-ups

### DIFF
--- a/frontend/asset.js
+++ b/frontend/asset.js
@@ -41,6 +41,9 @@ class Asset {
         }
         return server_entry;
     }
+    getServerCount() {
+        return this.servers.length;
+    }
     sendCommand(data)
     {
         for (var s in this.servers)

--- a/frontend/fssweb.css
+++ b/frontend/fssweb.css
@@ -21,9 +21,17 @@ div.server, div.asset {
 	border-style: solid;
 	background-color: whitesmoke;
 	width: max-content;
-	padding: 10px;
-	margin: 0 10px;
+	padding: 15px;
+	margin: 2px 10px;
 	text-align: left;
+}
+
+.asset-buttons {
+	padding-bottom: 1rem;
+}
+
+.server-tab-btn {
+	margin:3px;
 }
 
 div.dialog-map {
@@ -45,8 +53,6 @@ div.server-label-connected {
 	color: green;
 }
 
-div.server-status {
-}
 
 .server-status-label {
 	border: 1px;

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -208,16 +208,20 @@ function assetAddIfNew(asset_data)
             <div class="asset" id="asset_${asset.name}">
                 <div class="asset-label" id="asset_label_${asset.name}">${asset.name}</div>
                 <div class="asset-buttons btn-group" role="group" id="asset_buttons_${asset.name}">
-                    <button class="btn btn-light" id="asset_buttons_${asset.name}_rtl">RTL</button>
-                    <button class="btn btn-light" id="asset_buttons_${asset.name}_hold">Hold</button>
-                    <button class="btn btn-light" id="asset_buttons_${asset.name}_altitude">Altitude</button>
-                    <button class="btn btn-light" id="asset_buttons_${asset.name}_goto">Goto</button>
-                    <button class="btn btn-light" id="asset_buttons_${asset.name}_continue">Continue</button>
+                    <button class="btn btn-outline-secondary" id="asset_buttons_${asset.name}_rtl">RTL</button>
+                    <button class="btn btn-outline-secondary" id="asset_buttons_${asset.name}_hold">Hold</button>
+                    <button class="btn btn-outline-secondary" id="asset_buttons_${asset.name}_altitude">Altitude</button>
+                    <button class="btn btn-outline-secondary" id="asset_buttons_${asset.name}_goto">Goto</button>
+                    <button class="btn btn-outline-secondary" id="asset_buttons_${asset.name}_continue">Continue</button>
                     <button class="btn btn-info" id="asset_buttons_${asset.name}_manual">Manual</button>
                     <button class="btn btn-danger" id="asset_buttons_${asset.name}_disarm">DisArm</button>
                     <button class="btn btn-danger" id="asset_buttons_${asset.name}_terminate">Terminate</button>
+                </div>  
+                <div class="container card">
+                    <ul class="nav nav-tabs server-tab-btn" id="asset_server_select_${asset.name}">    
+                    </ul>
+                    <div class="asset-status tab-content" id="asset_status_${asset.name}"></div>
                 </div>
-                <div class="asset-status" id="asset_status_${asset.name}"></div>
             </div>`;
 
         $("div#assets").append(html);
@@ -239,16 +243,29 @@ function UIAssetStatus(asset)
     return $('#asset_status_' + asset.name);
 }
 
+function UIAssetServerSelect(asset)
+{
+    return $('#asset_server_select_' + asset.name);
+}
+
 function UIAssetServerIdPrefix(server_entry)
 {
     return 'asset_status_' + server_entry.asset.name + '_server_' + server_entry.server.name;
 }
 
+function shouldBeActiveAssetServerTab(asset) {
+    return asset.getServerCount() === 1;
+}
+
 function UIAssetServerAdd(server_entry)
 {
     let id_prefix = UIAssetServerIdPrefix(server_entry);
+    let active = '';
+    if(shouldBeActiveAssetServerTab(server_entry.asset)) {
+            active = 'active';
+    }
     let html = `
-    <div class="asset-status-server" id="${id_prefix}">
+    <div class="asset-status-server tab-pane ${active}" id="${id_prefix}">
         <div class="asset-status-server-label">${server_entry.server.name}</div>
         <div class="asset-status-command" id="${id_prefix}_command"></div>
         <table class="asset-rtt-status" id="${id_prefix}_rtt">
@@ -283,6 +300,14 @@ function UIAssetServerAdd(server_entry)
             </table>
     </div>`;
     UIAssetStatus(server_entry.asset).append(html);
+
+    const serverEntry = `
+            <li class="nav-item">
+                <button data-toggle="tab" class="nav-link server-tab-btn ${active}" href="#${id_prefix}">
+                    ${server_entry.server.name}
+                </button>
+            </li>`
+    UIAssetServerSelect(server_entry.asset).append(serverEntry);
 }
 
 function fieldMarkOld(field, timestamp, old, warn, prefix)


### PR DESCRIPTION
* Make server tab buttons look more like tabs
* Distinguish asset-buttons from background with outline
* Add container pane for asset-server status
* Make first server tab the active tab. This means the asset-server
status pane no longer needs to wait for the 'direct' server entry
to be loaded before becoming visible.