### PR TITLE
frontend: make sure to load direct data at page open

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -465,7 +465,9 @@ function serversUpdateKnown()
 function setupPage()
 {
     $.ajaxSetup({timeout: 2500 });
-    UIServerNew (serverAdd ({name: 'direct', address: '127.0.0.1', client_port: '0', url: window.location.href.slice(0, -1) }));
+    let direct = serverAdd ({name: 'direct', address: '127.0.0.1', client_port: '0', url: window.location.href.slice(0, -1) });
+    UIServerNew (direct);
+    serverUpdateStatus(direct);
     serversUpdateKnown();
     setInterval(function () {
         for (var ks in known_servers)


### PR DESCRIPTION
This makes it so data is available immediately, instead of waiting
for an update interval to show the data.