### PR TITLE
settings: bring back the csrf middleware

### DIFF
--- a/fss/settings.py
+++ b/fss/settings.py
@@ -47,6 +47,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
Removing this is no longer required because acceptable cross-site friends
are now configurable