### PR TITLE
settings: bring back the csrf middleware

### DIFF
--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -12,6 +12,7 @@ TIME_ZONE = 'UTC'
 
 # Allow all hosts
 ALLOWED_HOSTS = ['*']
+CSRF_TRUSTED_ORIGINS = ['http://localhost:8080']
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases

--- a/fss/local_settings.py.template
+++ b/fss/local_settings.py.template
@@ -12,6 +12,7 @@ TIME_ZONE = 'UTC'
 
 # Update this with your hostname
 ALLOWED_HOSTS = ['localhost']
+CSRF_TRUSTED_ORIGINS = ['http://localhost:8080']
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases

--- a/fss/settings.py
+++ b/fss/settings.py
@@ -47,6 +47,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/main/templates/main/login_page.html
+++ b/main/templates/main/login_page.html
@@ -7,6 +7,7 @@
         </head>
     <body>
         <form method="POST">
+            {% csrf_token %}
             <table>
                 <tr>
                     <td>Username</td>


### PR DESCRIPTION
Removing this is no longer required because acceptable cross-site friends
are now configurable