### PR TITLE
build: don't require nodejs in the final docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,6 +20,9 @@ jobs:
       run: |
           docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
 
+    - name: Build the frontend
+      run: ./build-frontend.sh
+
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_REPO }}:${{ github.sha }} --tag ${{ secrets.DOCKER_REPO }}:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y libgdal-dev nodejs npm && rm -fr /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libgdal-dev && rm -fr /var/lib/apt/lists/*
 RUN mkdir /code
 WORKDIR /code
 COPY . /code/
-RUN ./setup.sh
+RUN NODE_DONE=yes ./setup.sh
 
 ENTRYPOINT /code/docker/start.sh

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker run --mount type=bind,source=$(pwd),target=/usr/src node:20-slim /bin/bash -c "cd /usr/src; npm ci; npm run check; npm run build-only; chown $(id -u):$(id -g) -R dist node_modules; cp -dpR dist/* main/static/"

--- a/esbuild.config.json
+++ b/esbuild.config.json
@@ -1,4 +1,8 @@
 {
+    "entry": [
+        "frontend/main.js",
+        "frontend/pretty.js"
+    ],
     "bundle": true,
     "minify": false,
     "outdir": "dist",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "frontend/main.js",
   "scripts": {
     "check": "eslint frontend/",
-    "build": "esbuild frontend/main.js frontend/pretty.js $(esbuild-config) && cp -dpR dist/* main/static/",
+    "build-only": "esbuild $(esbuild-config)",
+    "build": "esbuild $(esbuild-config) && cp -dpR dist/* main/static/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,11 @@ pip install wheel
 pip install -r requirements.txt
 
 # Prepare the frontend
-npm ci && npm run build
+if [ "x${NODE_DONE}" != "xyes" ]
+then
+    npm ci
+    npm run build
+fi
 
 # Create the local settings file from the template
 if [ ! -f fss/local_settings.py ]


### PR DESCRIPTION
## Description

Build the frontend before building the docker image to avoid needing to put node into the resulting image.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change