### PR TITLE
Make sure the status is shown for each asset

### DIFF
--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -49,7 +49,7 @@ export class Asset {
     if (serverEntry === undefined) {
       const newAssetServer = new AssetServer(server, this, pk)
       this.servers.push(newAssetServer)
-      if (this.selectedServer === null) {
+      if (!this.selectedServer) {
         this.selectedServer = newAssetServer
       }
       return newAssetServer


### PR DESCRIPTION
## Description

The default server selection was not working because the match was checking for null when it was undefined.
This resulted in the page not showing any asset status information until the user clicked on a server, this is different from the previous behaviour.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where asset status information was not displayed by default.