### PR TITLE
Fix adding reported servers

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -755,8 +755,8 @@ export class FSSMainPage extends React.Component<never, FSSMainPageState> {
 
   serverAdd(server: ServerDetails) {
     const existing = this.serverFind(server.name)
-    if (existing === null) {
-      const newServer = new Server(server.name, server.address, server.clientPort, server.url)
+    if (!existing) {
+      const newServer = new Server(server.name, server.address, server.client_port, server.url)
       this.setState(function (prevState) {
         prevState.knownServers.push(newServer)
         return { knownServers: prevState.knownServers }


### PR DESCRIPTION
## Description

The return code of findServer was changed to undefined instead of null in a previous patch and not updated in the serverAdd function Also, clientPort and client_port were confused

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Fix server addition logic by correcting port parameter and handling undefined server lookup

Bug Fixes:
- Corrected server addition to handle undefined server lookup instead of explicitly checking for null
- Fixed inconsistent port parameter naming from clientPort to client_port