### PR TITLE
Specify the versions of python dependencies

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.13
       - name: Setup venv
         run: |
           ./setup.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-django
+django==5.2.1
 
-django-cors-headers
+django-cors-headers==4.7.0
 
-psycopg[binary,pool]==3.2.8
+psycopg[binary,pool]==3.2.9
 
 # Code checking
-pycodestyle
-pylint==3.3.*
+pycodestyle==2.13.0
+pylint==3.3.7
 pylint-django==2.6.1
-isort
+isort==6.0.1
 
-uwsgi
+uwsgi==2.0.29


### PR DESCRIPTION
## Description

This helps ensure a tested version is being used

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Build:
- Pin django to 5.2.1, django-cors-headers to 4.7.0, psycopg[binary,pool] to 3.2.9, pycodestyle to 2.13.0, pylint to 3.3.7, isort to 6.0.1, and uwsgi to 2.0.29