### PR TITLE
Don't explode if there is no config for an asset

### DIFF
--- a/config/templates/config/main.html
+++ b/config/templates/config/main.html
@@ -57,8 +57,12 @@
 {% for asset in Assets %}
 <tr>
 <td>{{ asset.name }}</td>
+{% if asset.config %}
 <td>{{ asset.config.smm.name }}</td>
 <td>{{ asset.config.smm_login }}</td>
+{% else %}
+<td colspan="2">No config</td>
+{% endif %}
 </tr>
 {% endfor %}
 </table>

--- a/config/views.py
+++ b/config/views.py
@@ -12,10 +12,11 @@ def config_main(request):
     """
     Main configuration page
     """
-    assets = Asset.objects.all()
+    assets = list(Asset.objects.all())
+    configs_by_asset_id = {c.asset_id: c for c in AssetConfig.objects.filter(asset__in=assets)}
 
     for asset in assets:
-        asset.config = AssetConfig.objects.get(asset=asset)
+        asset.config = configs_by_asset_id.get(asset.id)
 
     data = {
         'FSSservers': ServerConfig.objects.all(),


### PR DESCRIPTION
## Summary by Sourcery

Handle assets without associated configuration more gracefully

Bug Fixes:
- Avoid errors when an asset lacks an associated AssetConfig and display a fallback message in the configuration page

Enhancements:
- Reduce database queries by pre-fetching all AssetConfig objects for the listed assets and mapping them by asset ID