### PR TITLE
Remove unneeded get_command_display function

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -113,19 +113,6 @@ class AssetCommand(models.Model):
     def __str__(self):
         return f"Command {self.asset} to {self.get_command_display()}"
 
-    def get_command_display(self):
-        """
-        Convert the command into the displayable name
-        """
-        return next(
-            (
-                command_choice[1]
-                for command_choice in self.COMMAND_CHOICES
-                if command_choice[0] == self.command
-            ),
-            self.command,
-        )
-
     class Meta:
         indexes = [
             models.Index(fields=['asset', 'timestamp', ]),


### PR DESCRIPTION
Django already implements this, so need need to define it.

## Summary by Sourcery

Remove the custom get_command_display helper from AssetCommand now that Django provides this display functionality natively.