### PR TITLE
Use postgis/postgis docker image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,10 @@ services:
       - DJANGO_SUPERUSER_PASSWORD=administrator
       - DJANGO_SUPERUSER_EMAIL=me@example.com
   db:
-    image: mdillon/postgis
+    image: postgis/postgis:18-3.6-alpine
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
     healthcheck:
       test: "pg_isready --username=postgres"
       timeout: 10s


### PR DESCRIPTION
Replaces mdillon/postgis which is no longer maintained.

## Summary by Sourcery

Build:
- Update docker-compose configuration to use postgis/postgis:18-3.6-alpine and define default Postgres credentials for the db service.