### PR TITLE
Split dev and production python requirements

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -1,6 +1,14 @@
 #!/bin/bash -ex
 
+if [ ! -d venv ]
+then
+	python3 -m venv venv
+fi
+
 source venv/bin/activate
+
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
 
 PATHS="fss/ main/ config/ assets/"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Code checking
+pycodestyle==2.14.0
+pylint==4.0.5
+pylint-django==2.7.0
+isort==8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,4 @@ django-cors-headers==4.9.0
 
 psycopg[binary,pool]==3.3.4
 
-# Code checking
-pycodestyle==2.14.0
-pylint==4.0.5
-pylint-django==2.7.0
-isort==8.0.1
-
 uwsgi==2.0.31


### PR DESCRIPTION
## Summary by Sourcery

Split Python runtime and development dependencies and update the code-check script to install both sets into a virtual environment before running checks.

Build:
- Separate production dependencies from development-only tools into dedicated requirements files.

Chores:
- Update local code-check script to create/activate a virtualenv and install runtime and dev requirements before running linters and formatters.