### PR TITLE
perf(api): fix N+1 queries in status polling endpoint (PERF-01)

### DIFF
--- a/assets/views.py
+++ b/assets/views.py
@@ -6,11 +6,14 @@ import contextlib
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import csrf_exempt
 
 from .models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
+
+RTT_SAMPLE_LIMIT = 15
 
 
 def assets_main(request):
@@ -23,81 +26,220 @@ def assets_main(request):
     return render(request, 'assets/main.html', data)
 
 
-def asset_status_data(asset):
-    """
-    Get all the current status data for an asset
-    """
-    data = {
-        'asset': {
-            'name': asset.name,
-            'pk': asset.pk
-        }
+def _format_position(pos):
+    if not pos:
+        return None
+    return {
+        'timestamp': pos.timestamp,
+        'lat': pos.position.y,
+        'lng': pos.position.x,
+        'alt': pos.altitude,
     }
 
-    with contextlib.suppress(ObjectDoesNotExist):
-        position = AssetPosition.objects.filter(asset=asset).latest('timestamp')
-        data['position'] = {
-            'timestamp': position.timestamp,
-            'lat': position.position.y,
-            'lng': position.position.x,
-            'alt': position.altitude,
-        }
-    with contextlib.suppress(ObjectDoesNotExist):
-        status = AssetStatus.objects.filter(asset=asset).latest('timestamp')
-        data['status'] = {
-            'timestamp': status.timestamp,
-            'battery_percent': status.bat_percent,
-            'battery_used': status.bat_used_mah,
-            'battery_voltage': status.bat_volt,
-        }
-    with contextlib.suppress(ObjectDoesNotExist):
-        search = AssetSearchProgress.objects.filter(asset=asset).latest('timestamp')
-        data['search'] = {
-            'timestamp': search.timestamp,
-            'id': search.search,
-            'progress': search.search_progress,
-            'total': search.search_progress_of,
-        }
-    with contextlib.suppress(IndexError):
-        calculate_rtt_min_max_avg(asset, data)
-    with contextlib.suppress(ObjectDoesNotExist):
-        command = AssetCommand.objects.filter(asset=asset).latest('timestamp')
-        data['command'] = {
-            'timestamp': command.timestamp,
-            'command': command.get_command_display(),
-        }
-        if command.position:
-            data['command']['lat'] = command.position.y
-            data['command']['lng'] = command.position.x
-        if command.altitude is not None:
-            data['command']['alt'] = command.altitude
-    return data
+
+def _format_status(stat):
+    if not stat:
+        return None
+    return {
+        'timestamp': stat.timestamp,
+        'battery_percent': stat.bat_percent,
+        'battery_used': stat.bat_used_mah,
+        'battery_voltage': stat.bat_volt,
+    }
 
 
-def calculate_rtt_min_max_avg(asset, data):
-    """
-    Determine the RTT min/max/avg from the last 15 samples
-    """
-    rtts = AssetRTT.objects.filter(asset=asset).order_by('-timestamp')[:15]
-    rtt_total = 0
-    rtt_min = -1
-    rtt_max = 0
-    count = 0
-    for rtt in rtts:
-        if rtt_min == -1:
-            rtt_min = rtt.rtt
+def _format_search(srch):
+    if not srch:
+        return None
+    return {
+        'timestamp': srch.timestamp,
+        'id': srch.search,
+        'progress': srch.search_progress,
+        'total': srch.search_progress_of,
+    }
+
+
+def _format_rtts(rtts):
+    if not rtts:
+        return None
+
+    # Initialize aggregates from the first RTT entry to avoid magic sentinel values
+    first = rtts[0]
+    rtt_total = first.rtt
+    rtt_min = first.rtt
+    rtt_max = first.rtt
+
+    for rtt in rtts[1:]:
         rtt_min = min(rtt_min, rtt.rtt)
         rtt_max = max(rtt_max, rtt.rtt)
         rtt_total += rtt.rtt
-        count += 1
-    rtt_avg = rtt_total / count if count > 0 else -1
-    data['rtt'] = {
-        'timestamp': rtts[0].timestamp,
-        'rtt': rtts[0].rtt,
+
+    rtt_avg = rtt_total / len(rtts)
+
+    return {
+        'timestamp': first.timestamp,
+        'rtt': first.rtt,
         'rtt_min': rtt_min,
         'rtt_max': rtt_max,
         'rtt_avg': round(rtt_avg),
     }
+
+
+def _format_command(cmd):
+    if not cmd:
+        return None
+    data = {
+        'timestamp': cmd.timestamp,
+        'command': cmd.get_command_display(),
+    }
+    if cmd.position:
+        data['lat'] = cmd.position.y
+        data['lng'] = cmd.position.x
+    if cmd.altitude is not None:
+        data['alt'] = cmd.altitude
+    return data
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def format_asset_status(asset, position=None, status=None, search=None, rtts=None, command=None):
+    """
+    Centralized formatting logic for asset status data.
+    """
+    data = {
+        'asset': {
+            'name': asset.name,
+            'pk': asset.pk,
+        }
+    }
+
+    pos_data = _format_position(position)
+    if pos_data:
+        data['position'] = pos_data
+
+    stat_data = _format_status(status)
+    if stat_data:
+        data['status'] = stat_data
+
+    srch_data = _format_search(search)
+    if srch_data:
+        data['search'] = srch_data
+
+    rtt_data = _format_rtts(rtts) if rtts is not None else None
+    if rtt_data:
+        data['rtt'] = rtt_data
+
+    cmd_data = _format_command(command)
+    if cmd_data:
+        data['command'] = cmd_data
+
+    return data
+
+
+def asset_status_data(asset):
+    """
+    Get all the current status data for an asset (single-asset, DB-backed).
+    """
+    position = status = search = command = None
+    rtts = []
+
+    with contextlib.suppress(ObjectDoesNotExist):
+        position = AssetPosition.objects.filter(asset=asset).latest('timestamp')
+
+    with contextlib.suppress(ObjectDoesNotExist):
+        status = AssetStatus.objects.filter(asset=asset).latest('timestamp')
+
+    with contextlib.suppress(ObjectDoesNotExist):
+        search = AssetSearchProgress.objects.filter(asset=asset).latest('timestamp')
+
+    with contextlib.suppress(IndexError):
+        rtts = list(
+            AssetRTT.objects.filter(asset=asset)
+            .order_by('-timestamp')[:RTT_SAMPLE_LIMIT]
+        )
+
+    with contextlib.suppress(ObjectDoesNotExist):
+        command = AssetCommand.objects.filter(asset=asset).latest('timestamp')
+
+    return format_asset_status(
+        asset,
+        position=position,
+        status=status,
+        search=search,
+        rtts=rtts,
+        command=command,
+    )
+
+
+def bulk_asset_status_data(assets):
+    """
+    Get current status data for a list of assets efficiently.
+    """
+    def latest_subquery(model):
+        return (
+            model.objects
+            .filter(asset=OuterRef('pk'))
+            .order_by('-timestamp')
+            .values('pk')[:1]
+        )
+
+    # Materialize annotated assets to avoid multiple database evaluations
+    annotated_assets = list(
+        assets.annotate(
+            pos_id=Subquery(latest_subquery(AssetPosition)),
+            stat_id=Subquery(latest_subquery(AssetStatus)),
+            srch_id=Subquery(latest_subquery(AssetSearchProgress)),
+            cmd_id=Subquery(latest_subquery(AssetCommand)),
+        )
+    )
+
+    # Fetch latest objects for all assets in 4 bulk queries
+    latest = {
+        'positions': {
+            p.asset_id: p
+            for p in AssetPosition.objects.filter(
+                pk__in=[a.pos_id for a in annotated_assets if a.pos_id]
+            )
+        },
+        'statuses': {
+            s.asset_id: s
+            for s in AssetStatus.objects.filter(
+                pk__in=[a.stat_id for a in annotated_assets if a.stat_id]
+            )
+        },
+        'searches': {
+            s.asset_id: s
+            for s in AssetSearchProgress.objects.filter(
+                pk__in=[a.srch_id for a in annotated_assets if a.srch_id]
+            )
+        },
+        'commands': {
+            c.asset_id: c
+            for c in AssetCommand.objects.filter(
+                pk__in=[a.cmd_id for a in annotated_assets if a.cmd_id]
+            )
+        },
+    }
+
+    # Fetch RTTs (up to RTT_SAMPLE_LIMIT per asset) in 1 bulk query
+    rtts_by_asset = {}
+    for rtt in AssetRTT.objects.filter(asset__in=assets).order_by('asset', '-timestamp'):
+        rtts = rtts_by_asset.setdefault(rtt.asset_id, [])
+        if len(rtts) < RTT_SAMPLE_LIMIT:
+            rtts.append(rtt)
+
+    results = []
+    for asset in annotated_assets:
+        results.append(
+            format_asset_status(
+                asset,
+                position=latest['positions'].get(asset.pk),
+                status=latest['statuses'].get(asset.pk),
+                search=latest['searches'].get(asset.pk),
+                rtts=rtts_by_asset.get(asset.pk, []),
+                command=latest['commands'].get(asset.pk),
+            )
+        )
+    return results
 
 
 def asset_status_json(request, asset_id):

--- a/main/views.py
+++ b/main/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from assets.models import Asset
-from assets.views import asset_status_data
+from assets.views import bulk_asset_status_data
 from config.models import ServerConfig
 
 
@@ -101,7 +101,6 @@ def all_status_data(request):
         data['servers'].append(server_details)
 
     assets = Asset.objects.all()
-    for asset in assets:
-        data['assets'].append(asset_status_data(asset))
+    data['assets'] = bulk_asset_status_data(assets)
 
     return JsonResponse(data)


### PR DESCRIPTION
## Summary by Sourcery

Optimize asset status polling by batching related queries and centralizing response formatting for single and multi-asset endpoints.

Enhancements:
- Introduce helper functions and a shared formatter to build asset status JSON consistently across endpoints.
- Add a bulk asset status query path that prefetches latest related objects and RTT samples per asset to avoid N+1 queries in aggregated status views.
- Replace per-asset status lookups in the all-assets status endpoint with the new bulk loader for improved performance.