### PR TITLE
chore(backend): remove dead status_view endpoint (BACKEND-01)

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -10,7 +10,6 @@ urlpatterns = [
     re_path(r'^servers.json$', views.server_list, name='server_list'),
     re_path(r'^assets.json$', views.asset_list, name='asset_list'),
     re_path(r'^$', views.main_view, name='main_view'),
-    re_path(r'^status/$', views.status_view, name='status_view'),
     re_path(r'^current/all.json/$', views.all_status_data, name='all_status_data'),
     re_path(r'^current_user/$', views.current_user, name='current_user'),
     re_path(r'^login/$', views.login_page, name='login_page'),

--- a/main/views.py
+++ b/main/views.py
@@ -2,7 +2,7 @@
 Main view functions
 """
 from django.contrib.auth import authenticate, login
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
@@ -17,14 +17,6 @@ def main_view(request):
     The default landing page
     """
     return render(request, 'main/main.html')
-
-
-def status_view(request):
-    """
-    Report the current status
-    """
-    assets = Asset.objects.all()
-    return HttpResponse(f'<tr><td class="server-status-label">Known Assets</td><td class="server-status-value">{assets.count()}</td></tr>')
 
 
 def server_list(request):


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the deprecated status_view handler and its associated URL route.