### PR TITLE
refactor(api): return 409 Conflict for duplicate assets

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -55,7 +55,7 @@ class AssetAPITest(TestCase):
         """Test adding a duplicate asset."""
         url = reverse('asset_add')
         response = self.client.post(url, {'asset_name': 'Test Drone'})
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content.decode(), 'Asset already exists')
 
     def test_asset_command_set_invalid_altitude(self):

--- a/assets/views.py
+++ b/assets/views.py
@@ -7,7 +7,7 @@ import contextlib
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import OuterRef, Subquery
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 
@@ -294,7 +294,7 @@ def asset_add(request):
         asset_name = request.POST.get('asset_name')
         if asset_name is not None:
             if Asset.objects.filter(name=asset_name).exists():
-                return HttpResponseForbidden("Asset already exists")
+                return HttpResponse("Asset already exists", status=409)
             asset = Asset(name=asset_name)
             asset.save()
             return HttpResponse("Created")


### PR DESCRIPTION
## Summary by Sourcery

Return HTTP 409 Conflict when attempting to create a duplicate asset instead of 403 Forbidden.

Bug Fixes:
- Adjust duplicate asset creation response code to use 409 Conflict to better reflect the error semantics.

Tests:
- Update duplicate asset test to expect a 409 Conflict status code.