### PR TITLE
Fixup csrf and other security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,45 @@ cd flight-safety-system-web
 ./start.sh
 ```
 
+## Deployment Requirements
+
+### HTTPS is mandatory
+
+All FSS web instances **must** be served over HTTPS. The authentication and
+CSRF security model depends on browser same-site cookie semantics: session and
+CSRF cookies are sent cross-origin only when both the sending and receiving
+origin are the same registered domain **and** the connection uses HTTPS.
+Serving any instance over plain HTTP breaks cross-server authentication and
+opens the session to eavesdropping on a safety-critical system.
+
+### Multi-server deployments must share a registered domain
+
+When running more than one FSS web instance (for redundancy), every instance
+must be on the same registered domain — for example `fss1.example.com` and
+`fss2.example.com`. Servers on different domains or bare IP addresses cannot
+exchange credentials cross-origin and will not be able to send authenticated
+commands to one another's assets.
+
+### Configure CORS_ALLOWED_ORIGINS on each instance
+
+Each instance must list its peer instances in `CORS_ALLOWED_ORIGINS` inside
+its `local_settings.py`. This allows the browser to send credentials to peer
+servers. Every peer must appear in every other peer's list.
+
+```python
+# local_settings.py
+CORS_ALLOWED_ORIGINS = [
+    'https://fss1.example.com',
+    'https://fss2.example.com',
+]
+```
+
+A server not listed in its peers' `CORS_ALLOWED_ORIGINS` will still receive
+and store data from aircraft, but the UI loaded from a peer will not be able
+to send authenticated commands to it.
+
 ## Deploying
-[Refer to Django mod_wsgi documentation](https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/)
+[Refer to Django uWSGI documentation](https://docs.djangoproject.com/en/6.0/howto/deployment/wsgi/uwsgi/)
 
 ## Authors
 See the list of [contributors](https://github.com/canterbury-air-patrol/flight-safety-system-web/contributors).

--- a/README.md
+++ b/README.md
@@ -23,20 +23,25 @@ cd flight-safety-system-web
 
 ### HTTPS is mandatory
 
-All FSS web instances **must** be served over HTTPS. The authentication and
-CSRF security model depends on browser same-site cookie semantics: session and
-CSRF cookies are sent cross-origin only when both the sending and receiving
-origin are the same registered domain **and** the connection uses HTTPS.
-Serving any instance over plain HTTP breaks cross-server authentication and
-opens the session to eavesdropping on a safety-critical system.
+All FSS web instances **must** be served over HTTPS. Session and CSRF cookies
+are marked `Secure` in production (`SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`),
+so they will not be transmitted over plain HTTP at all. Serving any instance
+over HTTP means operators cannot log in and no commands can be sent.
 
 ### Multi-server deployments must share a registered domain
 
 When running more than one FSS web instance (for redundancy), every instance
-must be on the same registered domain — for example `fss1.example.com` and
-`fss2.example.com`. Servers on different domains or bare IP addresses cannot
-exchange credentials cross-origin and will not be able to send authenticated
-commands to one another's assets.
+must share the same *registered domain* (eTLD+1) — for example
+`fss1.example.com` and `fss2.example.com` both have the registered domain
+`example.com`. Browsers treat these as *same-site*, which means `SameSite=Lax`
+session and CSRF cookies set by `fss2.example.com` are included in credentialed
+`fetch()` requests issued from a page at `fss1.example.com`. This is what
+allows a single browser tab to authenticate against multiple servers.
+
+Servers on different registered domains (e.g. `fss.alpha.com` and
+`fss.beta.com`) or bare IP addresses are *cross-site* and their cookies will
+not be sent cross-origin under `SameSite=Lax`. Such deployments are not
+supported.
 
 ### Configure CORS_ALLOWED_ORIGINS on each instance
 

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -112,8 +112,15 @@ class AssetAPITest(TestCase):
         response = self.client.post(url, {'command': 'ALT'})
         self.assertEqual(response.status_code, 400)
 
+    def test_asset_status_json_unauthenticated(self):
+        """Test asset_status_json rejects unauthenticated requests."""
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
     def test_asset_status_json_success(self):
         """Test asset_status_json for a valid asset."""
+        self.client.force_login(self.user)
         url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -122,12 +129,14 @@ class AssetAPITest(TestCase):
 
     def test_asset_status_json_not_found(self):
         """Test asset_status_json for a non-existent asset."""
+        self.client.force_login(self.user)
         url = reverse('asset_status_json', kwargs={'asset_id': 99999})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
     def test_asset_status_no_data(self):
         """Test an asset with no status/position/rtt data."""
+        self.client.force_login(self.user)
         asset = Asset.objects.create(name='Empty Drone')
         url = reverse('asset_status_json', kwargs={'asset_id': asset.pk})
         response = self.client.get(url)
@@ -140,6 +149,7 @@ class AssetAPITest(TestCase):
 
     def test_rtt_sample_limit(self):
         """Test that RTT calculation only uses the latest RTT_SAMPLE_LIMIT samples."""
+        self.client.force_login(self.user)
         total_samples = RTT_SAMPLE_LIMIT + 5
         for i in range(1, total_samples + 1):
             AssetRTT.objects.create(asset=self.asset, rtt=i)

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for the Asset API
 """
+from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -15,20 +16,34 @@ class AssetAPITest(TestCase):
     def setUp(self):
         self.client = Client()
         self.asset = Asset.objects.create(name='Test Drone')
+        self.user = get_user_model().objects.create_user(username='testuser', password='testpass')
+
+    def test_asset_command_set_unauthenticated(self):
+        """Test that unauthenticated command attempts are rejected."""
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'RTL'})
+        self.assertEqual(response.status_code, 403)
+
+    def test_asset_add_unauthenticated(self):
+        """Test that unauthenticated asset-add attempts are rejected."""
+        url = reverse('asset_add')
+        response = self.client.post(url, {'asset_name': 'New Drone'})
+        self.assertEqual(response.status_code, 403)
 
     def test_asset_command_set_rtl(self):
         """Test setting RTL command."""
+        self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
         response = self.client.post(url, {'command': 'RTL'})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), 'Created')
 
-        # Verify command was created
         cmd = AssetCommand.objects.filter(asset=self.asset).latest('timestamp')
         self.assertEqual(cmd.command, 'RTL')
 
     def test_asset_command_set_goto(self):
         """Test setting GOTO command with coordinates."""
+        self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
         response = self.client.post(url, {
             'command': 'GOTO',
@@ -44,15 +59,16 @@ class AssetAPITest(TestCase):
 
     def test_asset_add(self):
         """Test adding a new asset."""
+        self.client.force_login(self.user)
         url = reverse('asset_add')
         response = self.client.post(url, {'asset_name': 'New Drone'})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), 'Created')
-
         self.assertTrue(Asset.objects.filter(name='New Drone').exists())
 
     def test_asset_add_duplicate(self):
         """Test adding a duplicate asset."""
+        self.client.force_login(self.user)
         url = reverse('asset_add')
         response = self.client.post(url, {'asset_name': 'Test Drone'})
         self.assertEqual(response.status_code, 409)
@@ -60,25 +76,23 @@ class AssetAPITest(TestCase):
 
     def test_asset_command_set_invalid_altitude(self):
         """Test setting an invalid altitude."""
+        self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        # Above limit
         response = self.client.post(url, {'command': 'ALT', 'altitude': 1001})
         self.assertEqual(response.status_code, 400)
 
-        # Below limit
         response = self.client.post(url, {'command': 'ALT', 'altitude': -1})
         self.assertEqual(response.status_code, 400)
 
-        # Non-numeric
         response = self.client.post(url, {'command': 'ALT', 'altitude': 'high'})
         self.assertEqual(response.status_code, 400)
 
     def test_asset_command_set_invalid_coordinates(self):
         """Test setting invalid coordinates for GOTO."""
+        self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        # Invalid latitude
         response = self.client.post(url, {
             'command': 'GOTO',
             'latitude': 'invalid',
@@ -89,13 +103,12 @@ class AssetAPITest(TestCase):
 
     def test_asset_command_set_missing_params(self):
         """Test setting commands with missing required parameters."""
+        self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        # GOTO missing longitude
         response = self.client.post(url, {'command': 'GOTO', 'latitude': -43.0})
         self.assertEqual(response.status_code, 400)
 
-        # ALT missing altitude
         response = self.client.post(url, {'command': 'ALT'})
         self.assertEqual(response.status_code, 400)
 
@@ -127,7 +140,6 @@ class AssetAPITest(TestCase):
 
     def test_rtt_sample_limit(self):
         """Test that RTT calculation only uses the latest RTT_SAMPLE_LIMIT samples."""
-        # Create RTTs with values 1 to 20
         total_samples = RTT_SAMPLE_LIMIT + 5
         for i in range(1, total_samples + 1):
             AssetRTT.objects.create(asset=self.asset, rtt=i)
@@ -136,20 +148,21 @@ class AssetAPITest(TestCase):
         response = self.client.get(url)
         data = response.json()
 
-        # The latest samples should be (total_samples - RTT_SAMPLE_LIMIT + 1) to total_samples
         rtt_data = data['rtt']
         self.assertEqual(rtt_data['rtt_max'], total_samples)
         self.assertEqual(rtt_data['rtt_min'], total_samples - RTT_SAMPLE_LIMIT + 1)
 
     def test_asset_add_get_rejected(self):
-        """Test that GET request to asset_add is rejected."""
+        """Test that authenticated GET request to asset_add is rejected."""
+        self.client.force_login(self.user)
         url = reverse('asset_add')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode(), 'Only POST is supported')
 
     def test_asset_command_set_get_rejected(self):
-        """Test that GET request to asset_command_set is rejected."""
+        """Test that authenticated GET request to asset_command_set is rejected."""
+        self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)

--- a/assets/views.py
+++ b/assets/views.py
@@ -11,6 +11,8 @@ from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
+from fss.decorators import login_required_api
+
 from .models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
 
 RTT_SAMPLE_LIMIT = 15
@@ -255,6 +257,7 @@ def asset_status_json(request, asset_id):
     return JsonResponse(asset_status_data(asset))
 
 
+@login_required_api
 def asset_command_set(request, asset_id):
     """
     Set the command for a given asset
@@ -285,6 +288,7 @@ def asset_command_set(request, asset_id):
     return HttpResponseBadRequest("Only POST is supported")
 
 
+@login_required_api
 def asset_add(request):
     """
     Add an asset

--- a/assets/views.py
+++ b/assets/views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
-from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
 
@@ -255,7 +255,6 @@ def asset_status_json(request, asset_id):
     return JsonResponse(asset_status_data(asset))
 
 
-@csrf_exempt
 def asset_command_set(request, asset_id):
     """
     Set the command for a given asset

--- a/assets/views.py
+++ b/assets/views.py
@@ -248,6 +248,7 @@ def bulk_asset_status_data(assets):
     return results
 
 
+@login_required_api
 def asset_status_json(request, asset_id):
     """
     Show the current asset status

--- a/config/tests/test_views.py
+++ b/config/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for the Config API
 """
+from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -14,6 +15,7 @@ class ConfigViewTest(TestCase):
     """
     def setUp(self):
         self.client = Client()
+        self.user = get_user_model().objects.create_user(username='testuser', password='testpass')
         self.asset = Asset.objects.create(name='Test Drone')
         self.smm_server = SMMConfig.objects.create(name='SMM Server', address='2.2.2.2', port=9090)
         self.asset_config = AssetConfig.objects.create(asset=self.asset, smm=self.smm_server, smm_login='user', smm_password='pass')
@@ -26,8 +28,15 @@ class ConfigViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'main/main.html')
 
+    def test_config_data_json_unauthenticated(self):
+        """Test config_data_json rejects unauthenticated requests."""
+        url = reverse('config_data_json')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
     def test_config_data_json(self):
         """Test the configuration data JSON endpoint."""
+        self.client.force_login(self.user)
         url = reverse('config_data_json')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/config/views.py
+++ b/config/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from assets.models import Asset
+from fss.decorators import login_required_api
 
 from .models import AssetConfig, ServerConfig, SMMConfig
 
@@ -18,6 +19,7 @@ def config_main(request):
     return render(request, 'main/main.html')
 
 
+@login_required_api
 def config_data_json(request):
     """
     Return all configuration data as JSON

--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -14,6 +14,12 @@ TIME_ZONE = 'UTC'
 ALLOWED_HOSTS = ['*']
 CSRF_TRUSTED_ORIGINS = ['http://localhost:8080']
 
+# CORS: list every peer FSS web-server origin so browsers can send credentials
+# cross-origin. Each server must appear in the other servers' lists.
+# All entries must use HTTPS and share a registered domain (e.g. example.com).
+# Example: CORS_ALLOWED_ORIGINS = ['https://fss1.example.com', 'https://fss2.example.com']
+CORS_ALLOWED_ORIGINS = []
+
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 

--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -12,7 +12,14 @@ TIME_ZONE = 'UTC'
 
 # Allow all hosts
 ALLOWED_HOSTS = ['*']
+# NOTE: http:// here is for local Docker development only.
+# In production, all origins must be https:// (see Deployment Requirements in README).
 CSRF_TRUSTED_ORIGINS = ['http://localhost:8080']
+
+# Require the Secure flag on session and CSRF cookies so they are never sent
+# over plain HTTP. All production instances must be served over HTTPS.
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 # CORS: list every peer FSS web-server origin so browsers can send credentials
 # cross-origin. Each server must appear in the other servers' lists.

--- a/e2e/test_server_list.py
+++ b/e2e/test_server_list.py
@@ -1,4 +1,4 @@
-"""E2E tests for the server-list JSON endpoint (/current/all.json/).
+"""E2E tests for the status JSON endpoint (/current/all.json/).
 
 Regression for TEST-02: config_serverconfig was missing the name, config_port,
 and https columns in the e2e schema, so any test that exercised the Django
@@ -7,12 +7,17 @@ server-list response would get incomplete or wrong data.
 Run with: python manage.py test e2e
 Requires: PostgreSQL + PostGIS (same as the dev environment).
 """
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from config.models import ServerConfig
 
 
 class ServerListJsonTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username='testuser', password='testpass')
+        self.client.force_login(self.user)
+
     def test_returns_name_and_http_url(self):
         ServerConfig.objects.create(
             name="primary",

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -35,7 +35,11 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
       if (!server) return Promise.resolve()
       return fetch(getAssetServerURL(server, assetServer, 'command/set/'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+          'X-CSRFToken': server.csrfToken ?? ''
+        },
         body: new URLSearchParams(entries)
       }).then((r) => {
         if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -42,6 +42,7 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
         },
         body: new URLSearchParams(entries)
       }).then((r) => {
+        if (r.status === 403) throw new Error('not authenticated — please refresh and log in')
         if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
       })
     })
@@ -50,7 +51,7 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
   const failures = results.map((result, i) => ({ result, serverName: assetServers[i].serverName })).filter(({ result }) => result.status === 'rejected')
 
   if (failures.length > 0) {
-    const errorMessages = failures
+    const failureMessages = failures
       .map(({ result, serverName }) => {
         const reason = (result as PromiseRejectedResult).reason
         const msg = reason instanceof Error ? reason.message : String(reason)
@@ -58,7 +59,8 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
       })
       .join(', ')
     const successCount = assetServers.length - failures.length
-    throw new Error(`Command reached ${successCount} of ${assetServers.length} server(s) for ${asset.name}; failed: ${errorMessages}`)
+    const prefix = successCount > 0 ? `Command was sent to ${successCount} of ${assetServers.length} server(s) — aircraft may already be affected. ` : ''
+    throw new Error(`${prefix}Failed on: ${failureMessages}`)
   }
 }
 

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -497,7 +497,7 @@ function FSSServerBar(props: FSSServerBarProps) {
 
 export const FSSMainPage: React.FC = () => {
   const [knownServers, setKnownServers] = useState<Record<string, ServerState>>({
-    direct: createServer('direct', '127.0.0.1', 0, window.location.href.slice(0, -1))
+    direct: createServer('direct', '127.0.0.1', 0, window.location.origin)
   })
   const [knownAssets, setKnownAssets] = useState<Record<string, AssetState>>({})
   const [lastError, setLastError] = useState<string | null>(null)

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -1,6 +1,6 @@
 import { degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
 import { AssetState, AssetServerState, AssetController, createAssetController, mergeServerAssets } from './asset'
-import { ServerState, createServer, getServerURL, serverConnectFailed, AssetPositionData, mergeServerPollResult } from './server'
+import { ServerState, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, mergeServerPollResult } from './server'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import L, { DragEndEvent } from 'leaflet'
@@ -517,11 +517,12 @@ export const FSSMainPage: React.FC = () => {
         const server = snapshotServers[serverName]
         try {
           const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include' })
+          if (response.status === 403) return { serverName, data: null, unauthenticated: true }
           if (!response.ok) throw new Error(`HTTP ${response.status}`)
           const data = await response.json()
-          return { serverName, data }
+          return { serverName, data, unauthenticated: false }
         } catch {
-          return { serverName, data: null }
+          return { serverName, data: null, unauthenticated: false }
         }
       })
     )
@@ -529,9 +530,13 @@ export const FSSMainPage: React.FC = () => {
     let currentServers = { ...knownServersRef.current }
     let currentAssets = { ...knownAssetsRef.current }
 
-    for (const { serverName, data } of results) {
+    for (const { serverName, data, unauthenticated } of results) {
       if (data === null) {
-        currentServers = { ...currentServers, [serverName]: serverConnectFailed(currentServers[serverName]) }
+        if (unauthenticated) {
+          currentServers = { ...currentServers, [serverName]: serverUnauthenticated(currentServers[serverName]) }
+        } else {
+          currentServers = { ...currentServers, [serverName]: serverConnectFailed(currentServers[serverName]) }
+        }
       } else {
         currentServers = mergeServerPollResult(currentServers, serverName, data)
         currentAssets = mergeServerAssets(currentAssets, serverName, data.assets)

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -516,7 +516,7 @@ export const FSSMainPage: React.FC = () => {
       serverNames.map(async (serverName) => {
         const server = snapshotServers[serverName]
         try {
-          const response = await fetch(getServerURL(server, '/current/all.json/'))
+          const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include' })
           if (!response.ok) throw new Error(`HTTP ${response.status}`)
           const data = await response.json()
           return { serverName, data }

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -104,6 +104,16 @@ export const serverConnectFailed = (server: ServerState): ServerState => ({
   userName: undefined
 })
 
+export const serverUnauthenticated = (server: ServerState): ServerState => ({
+  ...server,
+  connected: true,
+  status: 'Login required',
+  userName: undefined,
+  csrfToken: undefined,
+  assets: [],
+  servers: []
+})
+
 export const mergeServerPollResult = (currentServers: Record<string, ServerState>, serverName: string, data: StatusData): Record<string, ServerState> => {
   const nextServers = { ...currentServers, [serverName]: updateServerData(currentServers[serverName], data) }
   for (const s of data.servers) {

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -56,6 +56,7 @@ export interface ServerDetails {
 
 export interface StatusData {
   currentUser?: string
+  csrfToken: string
   servers: Array<ServerDetails>
   assets: Array<AssetStatus>
 }
@@ -67,6 +68,7 @@ export interface ServerState {
   url: string
   connected: boolean
   userName?: string
+  csrfToken?: string
   status: string
   assets: Array<AssetStatus>
   servers: Array<ServerDetails>
@@ -90,6 +92,7 @@ export const updateServerData = (server: ServerState, data: StatusData): ServerS
   connected: true,
   status: `Known Assets: ${data.assets.length}`,
   userName: data.currentUser,
+  csrfToken: data.csrfToken,
   assets: data.assets,
   servers: data.servers
 })

--- a/fss/decorators.py
+++ b/fss/decorators.py
@@ -1,0 +1,19 @@
+"""
+Shared view decorators.
+"""
+from functools import wraps
+
+from django.http import JsonResponse
+
+
+def login_required_api(view_func):
+    """
+    Like @login_required but returns 403 JSON instead of redirecting,
+    so fetch() callers receive an unambiguous error rather than a 200 HTML page.
+    """
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return JsonResponse({'error': 'Authentication required'}, status=403)
+        return view_func(request, *args, **kwargs)
+    return _wrapped

--- a/fss/settings.py
+++ b/fss/settings.py
@@ -115,3 +115,9 @@ STATICFILES_DIRS = [
 ]
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# CORS: restrict to the two endpoints that remote FSS servers need to access.
+# CORS_ALLOWED_ORIGINS must be set per deployment in local_settings.py.
+# All peer servers must share a registered domain and be served over HTTPS.
+CORS_URLS_REGEX = r'^/(current/all\.json|assets/\d+/command/set)/$'
+CORS_ALLOW_CREDENTIALS = True

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -21,16 +21,10 @@ class StatusAPITest(TestCase):
         self.server = ServerConfig.objects.create(name='Test Server', address='1.2.3.4', client_port=8080, active=True)
 
     def test_all_status_data_unauthenticated(self):
-        """Test the all_status_data endpoint when not logged in."""
+        """Test the all_status_data endpoint rejects unauthenticated requests."""
         url = reverse('all_status_data')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertIsNone(data['currentUser'])
-        self.assertEqual(len(data['servers']), 1)
-        self.assertEqual(data['servers'][0]['name'], 'Test Server')
-        self.assertEqual(len(data['assets']), 1)
-        self.assertEqual(data['assets'][0]['asset']['name'], 'Test Drone')
+        self.assertEqual(response.status_code, 403)
 
     def test_all_status_data_authenticated(self):
         """Test the all_status_data endpoint when logged in."""
@@ -40,9 +34,15 @@ class StatusAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['currentUser'], 'testuser')
+        self.assertEqual(len(data['servers']), 1)
+        self.assertEqual(data['servers'][0]['name'], 'Test Server')
+        self.assertEqual(len(data['assets']), 1)
+        self.assertEqual(data['assets'][0]['asset']['name'], 'Test Drone')
+        self.assertIn('csrfToken', data)
 
     def test_all_status_data_with_details(self):
         """Test with position and status data."""
+        self.client.login(username='testuser', password='password')
         AssetPosition.objects.create(asset=self.asset, position=Point(172.0, -43.0), altitude=100)
         AssetStatus.objects.create(asset=self.asset, bat_percent=85, bat_used_mah=500, bat_volt=11.1)
         AssetRTT.objects.create(asset=self.asset, rtt=50)
@@ -58,6 +58,7 @@ class StatusAPITest(TestCase):
 
     def test_all_status_data_with_altitude_zero(self):
         """Test that altitude 0 is correctly included in command data (Regression for DJANGO-01)."""
+        self.client.login(username='testuser', password='password')
         AssetCommand.objects.create(asset=self.asset, command='ALT', altitude=0)
 
         url = reverse('all_status_data')

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -84,6 +84,38 @@ class StatusAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['currentUser'], 'testuser')
 
+    def test_server_list_unauthenticated(self):
+        """Test server_list rejects unauthenticated requests."""
+        url = reverse('server_list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_server_list_authenticated(self):
+        """Test server_list returns data when logged in."""
+        self.client.login(username='testuser', password='password')
+        url = reverse('server_list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data['servers']), 1)
+        self.assertEqual(data['servers'][0]['name'], 'Test Server')
+
+    def test_asset_list_unauthenticated(self):
+        """Test asset_list rejects unauthenticated requests."""
+        url = reverse('asset_list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_asset_list_authenticated(self):
+        """Test asset_list returns data when logged in."""
+        self.client.login(username='testuser', password='password')
+        url = reverse('asset_list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data['assets']), 1)
+        self.assertEqual(data['assets'][0]['name'], 'Test Drone')
+
     def test_login_page_get(self):
         """Test login page GET request."""
         url = reverse('login_page')

--- a/main/views.py
+++ b/main/views.py
@@ -21,6 +21,7 @@ def main_view(request):
     return render(request, 'main/main.html')
 
 
+@login_required_api
 def server_list(request):
     """
     Return the active servers as a json array
@@ -39,6 +40,7 @@ def server_list(request):
     return JsonResponse({'servers': servers_list})
 
 
+@login_required_api
 def asset_list(request):
     """
     Return the know assets as a json array

--- a/main/views.py
+++ b/main/views.py
@@ -101,4 +101,6 @@ def all_status_data(request):
     assets = Asset.objects.all()
     data['assets'] = bulk_asset_status_data(assets)
 
-    return JsonResponse(data)
+    response = JsonResponse(data)
+    response['Cache-Control'] = 'private, no-store'
+    return response

--- a/main/views.py
+++ b/main/views.py
@@ -3,6 +3,7 @@ Main view functions
 """
 from django.contrib.auth import authenticate, login
 from django.http import JsonResponse
+from django.middleware.csrf import get_token
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
@@ -77,6 +78,7 @@ def all_status_data(request):
     """
     data = {
         'currentUser': None,
+        'csrfToken': get_token(request),
         'servers': [],
         'assets': []
     }

--- a/main/views.py
+++ b/main/views.py
@@ -10,6 +10,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from assets.models import Asset
 from assets.views import bulk_asset_status_data
 from config.models import ServerConfig
+from fss.decorators import login_required_api
 
 
 @ensure_csrf_cookie
@@ -72,6 +73,7 @@ def login_page(request):
     return render(request, 'main/main.html')
 
 
+@login_required_api
 def all_status_data(request):
     """
     Return all data in one go


### PR DESCRIPTION
## Summary by Sourcery

Tighten backend and frontend security around authenticated operations and CSRF while updating docs and tests to reflect the new behaviour.

New Features:
- Expose a CSRF token via the consolidated status JSON endpoint and plumb it through frontend server state for use in command requests.

Bug Fixes:
- Require authentication for status, configuration, asset, and server JSON endpoints and return JSON 403 errors instead of HTML redirects for unauthenticated API calls.
- Ensure asset command and asset creation endpoints are CSRF-protected and reject unauthenticated requests.
- Send credentials with cross-origin status and command requests so authenticated sessions work correctly across peer servers.
- Avoid treating authentication failures as connectivity errors in the frontend and surface clearer error messages when commands fail or authentication is missing.

Enhancements:
- Add a shared login_required_api decorator for consistent JSON-based auth enforcement across APIs.
- Prevent caching of the consolidated status JSON response to avoid stale authenticated data in browsers.
- Improve frontend error messaging when multi-server command dispatch partially fails, clarifying that aircraft may already be affected.

Deployment:
- Introduce CORS configuration in settings to restrict cross-origin access to specific JSON and command endpoints with credential support, and add secure cookie and CORS origin settings for Docker/local deployments.

Documentation:
- Document HTTPS, cookie, and CORS requirements for secure multi-server deployments and update deployment guidance to reference Django uWSGI docs.

Tests:
- Expand unit and end-to-end tests to cover authenticated vs unauthenticated behaviour for status, server, asset, config, and command endpoints, including CSRF token presence and RTT behaviour.