### PR TITLE
fix(api): validate command field before saving AssetCommand

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -74,6 +74,14 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content.decode(), 'Asset already exists')
 
+    def test_asset_command_set_invalid_command(self):
+        """Test that an unrecognised command is rejected."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'SELFDESTRUCT'})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content.decode(), 'Invalid command')
+
     def test_asset_command_set_invalid_altitude(self):
         """Test setting an invalid altitude."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -268,6 +268,9 @@ def asset_command_set(request, asset_id):
         point = None
         altitude = None
         command = request.POST.get('command')
+        valid_commands = dict(AssetCommand.COMMAND_CHOICES)
+        if command not in valid_commands:
+            return HttpResponseBadRequest('Invalid command')
         if command in AssetCommand.REQUIRES_POSITION:
             latitude = request.POST.get('latitude')
             longitude = request.POST.get('longitude')


### PR DESCRIPTION
## Description

Reject unknown command strings with 400 before constructing or saving the model instance. Django's choices constraint is not enforced at the DB level, so without this check any string could be persisted silently.

## Summary by Sourcery

Validate asset command input against defined choices before creating AssetCommand records.

Bug Fixes:
- Return HTTP 400 for unrecognised asset command values instead of silently persisting them.

Tests:
- Add a view test ensuring invalid asset commands are rejected with HTTP 400 and an 'Invalid command' message.