### PR TITLE
fix(api,frontend): compare command codes not display strings

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -135,6 +135,16 @@ class AssetAPITest(TestCase):
         data = response.json()
         self.assertEqual(data['asset']['name'], 'Test Drone')
 
+    def test_asset_status_json_command_code(self):
+        """Test that asset_status_json includes command_code alongside the display string."""
+        self.client.force_login(self.user)
+        AssetCommand.objects.create(asset=self.asset, command='RTL')
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(data['command']['command_code'], 'RTL')
+        self.assertEqual(data['command']['command'], 'Return to Launch')
+
     def test_asset_status_json_not_found(self):
         """Test asset_status_json for a non-existent asset."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -91,6 +91,7 @@ def _format_command(cmd):
     data = {
         'timestamp': cmd.timestamp,
         'command': cmd.get_command_display(),
+        'command_code': cmd.command,
     }
     if cmd.position:
         data['lat'] = cmd.position.y

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -368,15 +368,15 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
   let commandTxt: ReactNode = ''
   if (data?.command) {
     commandTxt = data.command.command
-    if (data.command.command === 'Goto Position') {
+    if (data.command.command_code === 'GOTO') {
       if (data.command.lat && data.command.lng) {
         commandTxt += ` ${degreesToDM(data.command.lat, true)}, ${degreesToDM(data.command.lng, false)}`
       }
     }
-    if (data.command.command === 'Adjust Altitude') {
+    if (data.command.command_code === 'ALT') {
       commandTxt += ` to ${data.command.alt}ft`
     }
-    if (data.command.command === 'Manual') {
+    if (data.command.command_code === 'MAN') {
       commandTxt = <strong>Take Manual Control Now</strong>
     }
   }

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -30,6 +30,7 @@ export interface AssetRTTData {
 export interface AssetCommandData {
   timestamp: string
   command: string
+  command_code: string
   lat?: number
   lng?: number
   alt?: number


### PR DESCRIPTION
## Description

Add command_code to the _format_command API response alongside the existing display string, and update the three comparisons in FSSAssetServerStatus to use command_code ('GOTO', 'ALT', 'MAN') instead of the Django display strings ('Goto Position', 'Adjust Altitude', 'Manual'). Breakage is now a type error, not a silent UI regression.

## Summary by Sourcery

Ensure asset command handling uses stable command codes instead of display strings across API and frontend.

New Features:
- Expose a command_code field in the asset_status_json API response alongside the human-readable command string.

Bug Fixes:
- Update FSS asset status UI logic to branch on command codes (GOTO, ALT, MAN) instead of translated display strings to prevent silent UI regressions.

Tests:
- Add a test verifying that asset_status_json returns both command_code and the display string for asset commands.