### PR TITLE
fix(frontend): cancel in-flight poll before starting the next one

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -508,7 +508,13 @@ export const FSSMainPage: React.FC = () => {
   knownServersRef.current = knownServers
   knownAssetsRef.current = knownAssets
 
+  const pollAbortRef = useRef<AbortController | null>(null)
+
   const updateData = useCallback(async () => {
+    pollAbortRef.current?.abort()
+    const ac = new AbortController()
+    pollAbortRef.current = ac
+
     const snapshotServers = knownServersRef.current
     const serverNames = Object.keys(snapshotServers)
 
@@ -516,7 +522,7 @@ export const FSSMainPage: React.FC = () => {
       serverNames.map(async (serverName) => {
         const server = snapshotServers[serverName]
         try {
-          const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include' })
+          const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include', signal: ac.signal })
           if (response.status === 403) return { serverName, data: null, unauthenticated: true }
           if (!response.ok) throw new Error(`HTTP ${response.status}`)
           const data = await response.json()
@@ -526,6 +532,8 @@ export const FSSMainPage: React.FC = () => {
         }
       })
     )
+
+    if (ac.signal.aborted) return
 
     let currentServers = { ...knownServersRef.current }
     let currentAssets = { ...knownAssetsRef.current }
@@ -550,7 +558,10 @@ export const FSSMainPage: React.FC = () => {
   useEffect(() => {
     updateData()
     const timer = setInterval(() => updateData(), 3000)
-    return () => clearInterval(timer)
+    return () => {
+      clearInterval(timer)
+      pollAbortRef.current?.abort()
+    }
   }, [updateData])
 
   const setAssetSelectedServer = (assetName: string, serverName: string) => {


### PR DESCRIPTION
## Description

Add an AbortController ref (pollAbortRef) that is aborted at the start of each updateData call. Pass its signal to every fetch so stale requests are cancelled rather than left to resolve out of order. Guard state updates with ac.signal.aborted so an aborted poll never overwrites server/asset state. Also abort on component unmount via the useEffect cleanup function.

## Summary by Sourcery

Ensure frontend polling cancels any in-flight requests before starting a new poll to prevent stale responses from updating state.

Bug Fixes:
- Cancel previous polling fetch requests using an AbortController before starting a new poll to avoid race conditions and stale state updates.
- Abort any ongoing poll when the component unmounts so no further state updates occur after teardown.