### PR TITLE
fix(security): enable HSTS and proxy SSL header in Docker settings (H-1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,10 @@ CSRF_TRUSTED_ORIGINS=
 
 # Comma-separated peer FSS server origins for multi-server deployments.
 CORS_ALLOWED_ORIGINS=
+
+# HSTS: set to seconds to enable (e.g. 31536000 for 1 year in production).
+# Requires a reverse proxy that sets X-Forwarded-Proto: https and strips any
+# client-supplied X-Forwarded-Proto header. Leave unset when running without a proxy.
+SECURE_HSTS_SECONDS=
+# SECURE_HSTS_INCLUDE_SUBDOMAINS=true
+# SECURE_HSTS_PRELOAD=false

--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -25,6 +25,21 @@ CSRF_TRUSTED_ORIGINS = [
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
+# HSTS: opt-in via SECURE_HSTS_SECONDS (e.g. 31536000 for 1 year).
+# Only set this when the container is behind a reverse proxy that strips and
+# rewrites X-Forwarded-Proto — without a trusted proxy, clients can forge that
+# header and cause Django to treat HTTP as HTTPS. Leave unset (or 0) when
+# running without a proxy (e.g. local development or direct-port deployments).
+# SECURE_HSTS_INCLUDE_SUBDOMAINS defaults true, covering peer FSS instances on
+# the same domain. SECURE_HSTS_PRELOAD defaults false because preload registration
+# is hard to undo; only enable it for domains that will remain HTTPS permanently.
+_hsts_seconds = int(os.environ.get('SECURE_HSTS_SECONDS', '0'))
+if _hsts_seconds:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    SECURE_HSTS_SECONDS = _hsts_seconds
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = os.environ.get('SECURE_HSTS_INCLUDE_SUBDOMAINS', 'true').lower() == 'true'
+    SECURE_HSTS_PRELOAD = os.environ.get('SECURE_HSTS_PRELOAD', 'false').lower() == 'true'
+
 # Peer FSS server origins for cross-origin credentialed fetches.
 # Each server must appear in the other servers' lists.
 CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
## Description

Add SECURE_PROXY_SSL_HEADER so Django's SecurityMiddleware can detect the request scheme when TLS is terminated by a reverse proxy. Add HSTS settings (31536000s, includeSubDomains, preload) so browsers enforce HTTPS after the first visit, preventing downgrade/strip attacks. The README states HTTPS is mandatory; this makes that requirement enforceable by the browser.

## Summary by Sourcery

Configure optional HSTS and proxy SSL header support for Docker-based deployments to enforce HTTPS when running behind a TLS-terminating reverse proxy.

New Features:
- Allow enabling HTTP Strict Transport Security via the SECURE_HSTS_SECONDS environment variable in Docker settings.
- Automatically configure Django's SECURE_PROXY_SSL_HEADER when HSTS is enabled so SecurityMiddleware can correctly detect HTTPS behind a reverse proxy.

Documentation:
- Document the new HSTS-related environment variables in the example .env file for Docker deployments.