### PR TITLE
fix(security): pin SESSION_COOKIE_SAMESITE and CSRF_COOKIE_SAMESITE to Lax

### DIFF
--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -24,6 +24,13 @@ CSRF_TRUSTED_ORIGINS = [
 # over plain HTTP. All production instances must be served over HTTPS.
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+# SameSite=Lax is the Django default but we pin it explicitly: the multi-server
+# architecture relies on Lax to allow credentialed cross-origin fetches between
+# FSS instances that share a registered domain (e.g. fss1.example.com →
+# fss2.example.com). Strict would break cross-origin polling; None would weaken
+# CSRF protection. This value must not be changed without reviewing SEC-01/02.
+SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_SAMESITE = 'Lax'
 
 # HSTS: opt-in via SECURE_HSTS_SECONDS (e.g. 31536000 for 1 year).
 # Only set this when the container is behind a reverse proxy that strips and


### PR DESCRIPTION
## Description

The multi-server architecture depends on SameSite=Lax to allow credentialed cross-origin fetches between FSS instances sharing a registered domain. Django already defaults to Lax but an explicit setting prevents a future Django version change or misconfiguration from silently breaking the cross-origin session model or weakening CSRF protection.

## Summary by Sourcery

Bug Fixes:
- Prevent unintended changes to session and CSRF behavior by explicitly setting SESSION_COOKIE_SAMESITE and CSRF_COOKIE_SAMESITE to Lax instead of relying on Django defaults.