### PR TITLE
fix(api): validate lat/lng range in asset_command_set

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -109,6 +109,20 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode(), 'Invalid Lat/Long')
 
+    def test_asset_command_set_out_of_range_coordinates(self):
+        """Test that out-of-range lat/lng values are rejected."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+
+        response = self.client.post(url, {'command': 'GOTO', 'latitude': 91.0, 'longitude': 172.0})
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.post(url, {'command': 'GOTO', 'latitude': -43.0, 'longitude': 181.0})
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.post(url, {'command': 'GOTO', 'latitude': -43.0, 'longitude': 172.0})
+        self.assertEqual(response.status_code, 200)
+
     def test_asset_command_set_missing_params(self):
         """Test setting commands with missing required parameters."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -276,7 +276,11 @@ def asset_command_set(request, asset_id):
             latitude = request.POST.get('latitude')
             longitude = request.POST.get('longitude')
             try:
-                point = Point(float(longitude), float(latitude))
+                lat = float(latitude)
+                lng = float(longitude)
+                if not -90 <= lat <= 90 or not -180 <= lng <= 180:
+                    raise ValueError
+                point = Point(lng, lat)
             except (ValueError, TypeError):
                 return HttpResponseBadRequest('Invalid Lat/Long')
         if command in AssetCommand.REQUIRES_ALTITUDE:


### PR DESCRIPTION
## Description

GOTO accepted any float for latitude and longitude — Point(999, 999) would be stored without error. Add the same bounded check already used for altitude: lat must be in [-90, 90] and lng in [-180, 180].

## Summary by Sourcery

Validate latitude and longitude ranges for GOTO asset commands and cover the behavior with tests.

Bug Fixes:
- Reject GOTO asset commands whose latitude or longitude fall outside the valid geographic bounds.

Tests:
- Add tests ensuring out-of-range latitude/longitude values for GOTO commands return 400 while valid coordinates succeed.