### PR TITLE
fix(settings): move local_settings import below BASE_DIR (BACKEND-05)

### DIFF
--- a/fss/settings.py
+++ b/fss/settings.py
@@ -12,14 +12,14 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 
 import os
 
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 try:
     # pylint: disable=W0401,W0614
     from fss.local_settings import *
 except ImportError:
     pass
-
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
## Description

local_settings was imported before BASE_DIR was defined. Any local_settings that referenced BASE_DIR would fail with a NameError. Move BASE_DIR above the import so it is always available to local_settings overrides.

## Summary by Sourcery

Bug Fixes:
- Fix NameError in local_settings when referencing BASE_DIR by defining BASE_DIR before importing local_settings.