### PR TITLE
fix(ux): use 'queued' not 'created/sent' for command success wording

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -36,7 +36,7 @@ class AssetAPITest(TestCase):
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
         response = self.client.post(url, {'command': 'RTL'})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode(), 'Created')
+        self.assertEqual(response.content.decode(), 'Queued')
 
         cmd = AssetCommand.objects.filter(asset=self.asset).latest('timestamp')
         self.assertEqual(cmd.command, 'RTL')

--- a/assets/views.py
+++ b/assets/views.py
@@ -293,7 +293,7 @@ def asset_command_set(request, asset_id):
         asset_command = AssetCommand(asset=asset, command=command,
                                      position=point, altitude=altitude)
         asset_command.save()
-        return HttpResponse("Created")
+        return HttpResponse("Queued")
     return HttpResponseBadRequest("Only POST is supported")
 
 

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -59,7 +59,7 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
       })
       .join(', ')
     const successCount = assetServers.length - failures.length
-    const prefix = successCount > 0 ? `Command was sent to ${successCount} of ${assetServers.length} server(s) — aircraft may already be affected. ` : ''
+    const prefix = successCount > 0 ? `Command was queued on ${successCount} of ${assetServers.length} server(s) — aircraft may already be affected. ` : ''
     throw new Error(`${prefix}Failed on: ${failureMessages}`)
   }
 }


### PR DESCRIPTION
## Description

This web app writes commands to the DB; the FSS daemon delivers them to aircraft. Saying 'Command was sent' implies aircraft delivery. Change the backend response body to 'Queued' and the partial-failure prefix to 'Command was queued on N server(s)' so operators understand the command is enqueued, not confirmed as received by the aircraft.

## Summary by Sourcery

Update command success messaging to clarify that commands are queued on servers rather than definitively sent to aircraft.

Bug Fixes:
- Correct command API response text from 'Created' to 'Queued' to accurately reflect enqueue behavior.
- Adjust partial failure frontend messaging to state commands were queued on a subset of servers instead of sent.