### PR TITLE
Minify docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,14 @@ fss/secretkey.txt
 __pycache__/
 .vscode/
 todo/
+.github/
+*.md
+requirements-dev.txt
+check-code.sh
+setup.sh
+setup-db.sh
+build-frontend.sh
+build-frontend-docker.sh
+start.sh
+start-wsgi.sh
+.env*

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,14 +14,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - name: Get node ready
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20.x'
-
-    - name: Build the frontend
-      run: ./build-frontend.sh
-
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm run build-only
 
 # Stage 2: Install Python dependencies
 FROM python:3.14-slim AS python-builder
-RUN apt-get update && apt-get install -y build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /tmp/
 RUN python3 -m venv /venv && \
     /venv/bin/pip install --no-cache-dir wheel && \
@@ -17,7 +17,7 @@ RUN python3 -m venv /venv && \
 # Stage 3: Runtime image
 FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y libgdal36 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libgdal36 && rm -rf /var/lib/apt/lists/*
 COPY --from=python-builder /venv /venv
 WORKDIR /code
 COPY --from=frontend /app/dist ./dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,31 @@
-FROM python:3.12-slim
-ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y libgdal-dev && rm -rf /var/lib/apt/lists/*
-RUN mkdir /code
-WORKDIR /code
-COPY . /code/
-RUN NODE_DONE=yes ./setup.sh
+# Stage 1: Build frontend bundle
+FROM node:26-slim AS frontend
+WORKDIR /app
+COPY package.json package-lock.json esbuild.config.json ./
+RUN npm ci
+COPY frontend/ ./frontend/
+RUN npm run build-only
 
+# Stage 2: Install Python dependencies
+FROM python:3.14-slim AS python-builder
+RUN apt-get update && apt-get install -y build-essential libgdal-dev && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /tmp/
+RUN python3 -m venv /venv && \
+    /venv/bin/pip install --no-cache-dir wheel && \
+    /venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Stage 3: Runtime image
+FROM python:3.14-slim
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y libgdal36 && rm -rf /var/lib/apt/lists/*
+COPY --from=python-builder /venv /venv
+WORKDIR /code
+COPY --from=frontend /app/dist ./dist/
+COPY fss/ ./fss/
+COPY main/ ./main/
+COPY config/ ./config/
+COPY assets/ ./assets/
+COPY manage.py ./
+COPY docker/ ./docker/
+ENV PATH="/venv/bin:$PATH"
 ENTRYPOINT ["/code/docker/start.sh"]

--- a/build-frontend-docker.sh
+++ b/build-frontend-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run --mount type=bind,source=$(pwd),target=/usr/src node:24-slim /bin/bash -c "cd /usr/src; USERID=$(id -u) GROUPID=$(id -g) ./build-frontend.sh"
+docker run --mount type=bind,source=$(pwd),target=/usr/src node:26-slim /bin/bash -c "cd /usr/src; USERID=$(id -u) GROUPID=$(id -g) ./build-frontend.sh"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -2,7 +2,7 @@
 set -e
 
 cp docker/local_settings.py fss/local_settings.py
-source venv/bin/activate
+source /venv/bin/activate
 
 ./manage.py migrate
 


### PR DESCRIPTION
## Summary by Sourcery

Minimize the Docker image by introducing a multi-stage build that compiles the frontend and installs Python dependencies in separate builder stages, then assembles a slimmer runtime image using the prebuilt artifacts.

Enhancements:
- Introduce a multi-stage Docker build that separates frontend compilation, Python dependency installation, and runtime to reduce image size and improve layering.
- Update the Docker startup script to use a virtual environment located at /venv instead of a project-local venv directory.
- Align local frontend build helper script to use a newer Node base image matching the Dockerfile build stage.

CI:
- Simplify the Docker image GitHub Actions workflow by removing separate Node setup and frontend build steps now handled inside the Docker build.