### PR TITLE
fix(docker): install mime-support so uWSGI serves .js with correct MIME type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN python3 -m venv /venv && \
 # Stage 3: Runtime image
 FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y --no-install-recommends libgdal36 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libgdal36 mime-support && rm -rf /var/lib/apt/lists/*
 COPY --from=python-builder /venv /venv
 WORKDIR /code
 COPY --from=frontend /app/dist ./dist/


### PR DESCRIPTION
## Description

python:3.14-slim has no /etc/mime.types; uWSGI's --static-map relies on it for Content-Type detection. Previously libgdal-dev (used in the old single-stage image) pulled mime-support in transitively. libgdal36 does not, causing main.js to be served with an empty Content-Type, which Firefox rejects for module scripts.