### PR TITLE
perf(config): eliminate N+1 query when loading SMM names in config_data_json

### DIFF
--- a/config/views.py
+++ b/config/views.py
@@ -25,7 +25,7 @@ def config_data_json(request):
     Return all configuration data as JSON
     """
     assets = list(Asset.objects.all())
-    configs_by_asset_id = {c.asset_id: c for c in AssetConfig.objects.filter(asset__in=assets)}
+    configs_by_asset_id = {c.asset_id: c for c in AssetConfig.objects.filter(asset__in=assets).select_related('smm')}
 
     fss_servers = []
     for s in ServerConfig.objects.all():


### PR DESCRIPTION
## Description

AssetConfig.smm was lazy-loaded inside a loop, causing one extra query per asset. select_related('smm') fetches it in the same JOIN.

## Summary by Sourcery

Enhancements:
- Load AssetConfig.smm via select_related to fetch related SMM records in a single query instead of per-asset lookups.