### PR TITLE
perf(assets): replace per-asset RTT queries with a single window-function query

### DIFF
--- a/assets/views.py
+++ b/assets/views.py
@@ -222,17 +222,18 @@ def bulk_asset_status_data(assets):
         },
     }
 
-    # Fetch RTTs (up to RTT_SAMPLE_LIMIT per asset)
-    # We do this per-asset because a bulk query with a limit-per-group is extremely
-    # inefficient in Django's ORM without complex raw SQL or lateral joins.
-    # Given the number of assets is small, N fast indexed queries is better
-    # than 1 query that fetches every RTT record in the database.
+    # Fetch the latest RTT_SAMPLE_LIMIT RTTs per asset in one query using a
+    # window function — Django ORM can't express LIMIT-per-group without raw SQL.
     rtts_by_asset = {}
-    for asset in annotated_assets:
-        rtts_by_asset[asset.pk] = list(
-            AssetRTT.objects.filter(asset=asset)
-            .order_by('-timestamp')[:RTT_SAMPLE_LIMIT]
-        )
+    asset_ids = [a.pk for a in annotated_assets]
+    if asset_ids:
+        placeholders = ','.join(['%s'] * len(asset_ids))
+        for rtt in AssetRTT.objects.raw(
+            "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY asset_id ORDER BY timestamp DESC) AS rn "
+            f"FROM assets_assetrtt WHERE asset_id IN ({placeholders})) t WHERE rn <= %s",
+            [*asset_ids, RTT_SAMPLE_LIMIT]
+        ):
+            rtts_by_asset.setdefault(rtt.asset_id, []).append(rtt)
 
     results = []
     for asset in annotated_assets:

--- a/assets/views.py
+++ b/assets/views.py
@@ -228,9 +228,11 @@ def bulk_asset_status_data(assets):
     asset_ids = [a.pk for a in annotated_assets]
     if asset_ids:
         placeholders = ','.join(['%s'] * len(asset_ids))
+        table_name = AssetRTT._meta.db_table
         for rtt in AssetRTT.objects.raw(
             "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY asset_id ORDER BY timestamp DESC) AS rn "
-            f"FROM assets_assetrtt WHERE asset_id IN ({placeholders})) t WHERE rn <= %s",
+            f"FROM {table_name} WHERE asset_id IN ({placeholders})) t WHERE rn <= %s "
+            "ORDER BY asset_id, rn",
             [*asset_ids, RTT_SAMPLE_LIMIT]
         ):
             rtts_by_asset.setdefault(rtt.asset_id, []).append(rtt)


### PR DESCRIPTION
## Description

bulk_asset_status_data() was executing one query per asset to fetch its latest RTT records. A single ROW_NUMBER() OVER (PARTITION BY asset_id) query now fetches all assets' RTTs in one round-trip. Django ORM can't express LIMIT-per-group without raw SQL.

## Summary by Sourcery

Enhancements:
- Use a single raw SQL window-function query to fetch the latest RTT samples for all assets instead of issuing one query per asset.