### PR TITLE
feat(assets): surface command-ack state in the status API

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -159,6 +159,43 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['command']['command_code'], 'RTL')
         self.assertEqual(data['command']['command'], 'Return to Launch')
 
+    def test_asset_status_json_ack_pending(self):
+        """A dispatched-but-unacked command reports ack_state 'pending'."""
+        self.client.force_login(self.user)
+        AssetCommand.objects.create(asset=self.asset, command='RTL')
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(data['command']['ack_state'], 'pending')
+        self.assertNotIn('ack_timestamp', data['command'])
+
+    def test_asset_status_json_ack_actioned(self):
+        """An actioned ack is surfaced with its code, label and timestamp."""
+        self.client.force_login(self.user)
+        AssetCommand.objects.create(
+            asset=self.asset, command='RTL',
+            ack_state=AssetCommand.ACK_ACTIONED, ack_timestamp=1700000000000,
+        )
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(data['command']['ack_state'], 'actioned')
+        self.assertEqual(data['command']['ack_state_display'], 'Actioned')
+        self.assertEqual(data['command']['ack_timestamp'], 1700000000000)
+
+    def test_asset_status_json_ack_superseded(self):
+        """A superseded ack carries the superseding-state enum int."""
+        self.client.force_login(self.user)
+        AssetCommand.objects.create(
+            asset=self.asset, command='MAN',
+            ack_state=AssetCommand.ACK_SUPERSEDED, ack_superseded_by=1,
+        )
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(data['command']['ack_state'], 'superseded')
+        self.assertEqual(data['command']['ack_superseded_by'], 1)
+
     def test_asset_status_json_not_found(self):
         """Test asset_status_json for a non-existent asset."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -85,6 +85,17 @@ def _format_rtts(rtts):
     }
 
 
+# Machine-readable codes for each ack outcome, paired with the human label
+# from AssetCommand.ACK_STATE_CHOICES. The codes are what the frontend
+# switches on; the display label is for convenience.
+ACK_STATE_CODES = {
+    AssetCommand.ACK_RECEIVED: 'received',
+    AssetCommand.ACK_ACTIONED: 'actioned',
+    AssetCommand.ACK_SUPERSEDED: 'superseded',
+    AssetCommand.ACK_REJECTED: 'rejected',
+}
+
+
 def _format_command(cmd):
     if not cmd:
         return None
@@ -98,6 +109,19 @@ def _format_command(cmd):
         data['lng'] = cmd.position.x
     if cmd.altitude is not None:
         data['alt'] = cmd.altitude
+    # Acknowledgement state. ack_state is NULL until the FSS server records an
+    # ack against this command, so a dispatched-but-unacked command reports
+    # 'pending'. ack_timestamp is the FMU's wall-clock epoch-ms, passed through
+    # for the frontend to render.
+    if cmd.ack_state is None:
+        data['ack_state'] = 'pending'
+    else:
+        data['ack_state'] = ACK_STATE_CODES.get(cmd.ack_state, 'pending')
+        data['ack_state_display'] = cmd.get_ack_state_display()
+    if cmd.ack_timestamp is not None:
+        data['ack_timestamp'] = cmd.ack_timestamp
+    if cmd.ack_superseded_by is not None:
+        data['ack_superseded_by'] = cmd.ack_superseded_by
     return data
 
 

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -27,6 +27,8 @@ export interface AssetRTTData {
   rtt_avg: number
 }
 
+export type AckState = 'pending' | 'received' | 'actioned' | 'superseded' | 'rejected'
+
 export interface AssetCommandData {
   timestamp: string
   command: string
@@ -34,6 +36,14 @@ export interface AssetCommandData {
   lat?: number
   lng?: number
   alt?: number
+  // Acknowledgement state. 'pending' means the command was dispatched but no
+  // ack has been recorded yet. ack_timestamp is the FMU's wall-clock epoch-ms.
+  // ack_superseded_by is the fss_asset_command enum int of the higher-priority
+  // state that blocked actioning, present only when ack_state is 'superseded'.
+  ack_state: AckState
+  ack_state_display?: string
+  ack_timestamp?: number
+  ack_superseded_by?: number
 }
 
 export interface AssetStatus {


### PR DESCRIPTION
## Description

Extend _format_command and the AssetCommandData TypeScript interface with the acknowledgement state. ack_state is emitted as a machine code ('pending' when no ack has been recorded yet, otherwise received/actioned/ superseded/rejected) alongside a display label; ack_timestamp (FMU epoch-ms) and ack_superseded_by (the superseding fss_asset_command enum int) are included when present.

## Summary by Sourcery

Expose asset command acknowledgement state and metadata via the asset status JSON API and its frontend types.

New Features:
- Include acknowledgement state, display label, timestamp, and superseding-command metadata for asset commands in the asset status JSON response.
- Extend frontend AssetCommandData typings with a dedicated AckState union type and optional acknowledgement metadata fields.

Tests:
- Add API tests covering pending, actioned, and superseded acknowledgement states in the asset status JSON response.