### PR TITLE
feat(assets): align command-ack with FSS enum v2

### DIFF
--- a/assets/migrations/0008_assetcommand_ack_state_and_more.py
+++ b/assets/migrations/0008_assetcommand_ack_state_and_more.py
@@ -20,6 +20,7 @@ class Migration(migrations.Migration):
                     (1, "Actioned"),
                     (2, "Superseded"),
                     (3, "Rejected"),
+                    (4, "No change"),
                 ],
                 null=True,
             ),
@@ -27,7 +28,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="assetcommand",
             name="ack_superseded_by",
-            field=models.SmallIntegerField(blank=True, null=True),
+            field=models.SmallIntegerField(
+                blank=True,
+                choices=[
+                    (0, "None"),
+                    (1, "Low Battery"),
+                    (2, "Comms Loss"),
+                ],
+                null=True,
+            ),
         ),
         migrations.AddField(
             model_name="assetcommand",

--- a/assets/models.py
+++ b/assets/models.py
@@ -121,16 +121,29 @@ class AssetCommand(models.Model):
     ACK_ACTIONED = 1    # state machine transitioned
     ACK_SUPERSEDED = 2  # not actioned: a higher-priority latch is engaged
     ACK_REJECTED = 3    # unknown/malformed/invalid command
+    ACK_NOOP = 4        # command resolved to the already-current state; nothing changed
     ACK_STATE_CHOICES = (
         (ACK_RECEIVED, "Received"),
         (ACK_ACTIONED, "Actioned"),
         (ACK_SUPERSEDED, "Superseded"),
         (ACK_REJECTED, "Rejected"),
+        (ACK_NOOP, "No change"),
+    )
+    # Reason a command was superseded (fss_command_ack_reason). Distinct from a
+    # command value so e.g. low-battery RTL and comms-loss RTL stay separable.
+    # Only set (non-zero) when ack_state == ACK_SUPERSEDED.
+    SUPERSEDE_NONE = 0
+    SUPERSEDE_LOW_BATTERY = 1
+    SUPERSEDE_COMMS_LOSS = 2
+    SUPERSEDE_REASON_CHOICES = (
+        (SUPERSEDE_NONE, "None"),
+        (SUPERSEDE_LOW_BATTERY, "Low Battery"),
+        (SUPERSEDE_COMMS_LOSS, "Comms Loss"),
     )
     dispatch_id = models.BigIntegerField(null=True, blank=True)
     ack_state = models.SmallIntegerField(null=True, blank=True, choices=ACK_STATE_CHOICES)
     ack_timestamp = models.BigIntegerField(null=True, blank=True)  # FMU wall-clock epoch-ms
-    ack_superseded_by = models.SmallIntegerField(null=True, blank=True)  # fss_asset_command enum int
+    ack_superseded_by = models.SmallIntegerField(null=True, blank=True, choices=SUPERSEDE_REASON_CHOICES)
 
     def __str__(self):
         return f"Command {self.asset} to {self.get_command_display()}"

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -184,17 +184,30 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['command']['ack_timestamp'], 1700000000000)
 
     def test_asset_status_json_ack_superseded(self):
-        """A superseded ack carries the superseding-state enum int."""
+        """A superseded ack carries the supersede reason as a code string."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(
             asset=self.asset, command='MAN',
-            ack_state=AssetCommand.ACK_SUPERSEDED, ack_superseded_by=1,
+            ack_state=AssetCommand.ACK_SUPERSEDED,
+            ack_superseded_by=AssetCommand.SUPERSEDE_LOW_BATTERY,
         )
         url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
         response = self.client.get(url)
         data = response.json()
         self.assertEqual(data['command']['ack_state'], 'superseded')
-        self.assertEqual(data['command']['ack_superseded_by'], 1)
+        self.assertEqual(data['command']['ack_superseded_by'], 'low_battery')
+
+    def test_asset_status_json_ack_noop(self):
+        """A noop ack (already-current state) reports ack_state 'noop'."""
+        self.client.force_login(self.user)
+        AssetCommand.objects.create(
+            asset=self.asset, command='RTL', ack_state=AssetCommand.ACK_NOOP,
+        )
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(data['command']['ack_state'], 'noop')
+        self.assertEqual(data['command']['ack_state_display'], 'No change')
 
     def test_asset_status_json_not_found(self):
         """Test asset_status_json for a non-existent asset."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -93,6 +93,15 @@ ACK_STATE_CODES = {
     AssetCommand.ACK_ACTIONED: 'actioned',
     AssetCommand.ACK_SUPERSEDED: 'superseded',
     AssetCommand.ACK_REJECTED: 'rejected',
+    AssetCommand.ACK_NOOP: 'noop',
+}
+
+# Machine-readable codes for the supersede reason (fss_command_ack_reason),
+# meaningful only when ack_state is 'superseded'.
+ACK_SUPERSEDE_REASON_CODES = {
+    AssetCommand.SUPERSEDE_NONE: 'none',
+    AssetCommand.SUPERSEDE_LOW_BATTERY: 'low_battery',
+    AssetCommand.SUPERSEDE_COMMS_LOSS: 'comms_loss',
 }
 
 
@@ -121,7 +130,7 @@ def _format_command(cmd):
     if cmd.ack_timestamp is not None:
         data['ack_timestamp'] = cmd.ack_timestamp
     if cmd.ack_superseded_by is not None:
-        data['ack_superseded_by'] = cmd.ack_superseded_by
+        data['ack_superseded_by'] = ACK_SUPERSEDE_REASON_CODES.get(cmd.ack_superseded_by, 'none')
     return data
 
 

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -1,6 +1,16 @@
 import { degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
 import { AssetState, AssetServerState, AssetController, createAssetController, mergeServerAssets } from './asset'
-import { ServerState, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, AssetCommandData, mergeServerPollResult } from './server'
+import {
+  ServerState,
+  createServer,
+  getServerURL,
+  serverConnectFailed,
+  serverUnauthenticated,
+  AssetPositionData,
+  AssetCommandData,
+  AckSupersedeReason,
+  mergeServerPollResult
+} from './server'
 import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import L, { DragEndEvent } from 'leaflet'
@@ -273,6 +283,14 @@ const dataAgeClass = (timestamp: string, old: number, warn: number, prefix: stri
   return ''
 }
 
+// Label for the failsafe latch that superseded a command. The latch always
+// engages an RTL, so name it as such for the operator.
+const supersedeReasonLabel: Record<AckSupersedeReason, string> = {
+  none: '',
+  low_battery: 'low-battery RTL',
+  comms_loss: 'comms-loss RTL'
+}
+
 // Render the acknowledgement state of a command as a short suffix plus a CSS
 // class for styling. A 'pending' ack that has outlived commandAckTimeout is
 // reported distinctly ('no ack') so an ack that never arrives is visible
@@ -283,8 +301,12 @@ const commandAckDisplay = (command: AssetCommandData): { text: string; className
       return { text: '✓ actioned', className: 'asset-command-ack-actioned' }
     case 'received':
       return { text: '… received', className: 'asset-command-ack-received' }
-    case 'superseded':
-      return { text: '✗ superseded', className: 'asset-command-ack-superseded' }
+    case 'noop':
+      return { text: '✓ no change', className: 'asset-command-ack-noop' }
+    case 'superseded': {
+      const reason = command.ack_superseded_by && command.ack_superseded_by !== 'none' ? ` by ${supersedeReasonLabel[command.ack_superseded_by]}` : ''
+      return { text: `✗ superseded${reason}`, className: 'asset-command-ack-superseded' }
+    }
     case 'rejected':
       return { text: '✗ rejected', className: 'asset-command-ack-rejected' }
     case 'pending':

--- a/frontend/fssweb.css
+++ b/frontend/fssweb.css
@@ -95,7 +95,8 @@ div.server-label-connected {
   font-size: smaller;
 }
 
-.asset-command-ack-actioned {
+.asset-command-ack-actioned,
+.asset-command-ack-noop {
   color: green;
 }
 

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -27,7 +27,8 @@ export interface AssetRTTData {
   rtt_avg: number
 }
 
-export type AckState = 'pending' | 'received' | 'actioned' | 'superseded' | 'rejected'
+export type AckState = 'pending' | 'received' | 'actioned' | 'superseded' | 'rejected' | 'noop'
+export type AckSupersedeReason = 'none' | 'low_battery' | 'comms_loss'
 
 export interface AssetCommandData {
   timestamp: string
@@ -37,13 +38,14 @@ export interface AssetCommandData {
   lng?: number
   alt?: number
   // Acknowledgement state. 'pending' means the command was dispatched but no
-  // ack has been recorded yet. ack_timestamp is the FMU's wall-clock epoch-ms.
-  // ack_superseded_by is the fss_asset_command enum int of the higher-priority
-  // state that blocked actioning, present only when ack_state is 'superseded'.
+  // ack has been recorded yet; 'noop' means it resolved to the already-current
+  // state. ack_timestamp is the FMU's wall-clock epoch-ms. ack_superseded_by is
+  // the reason a command was superseded (which failsafe latch blocked it),
+  // present only when ack_state is 'superseded'.
   ack_state: AckState
   ack_state_display?: string
   ack_timestamp?: number
-  ack_superseded_by?: number
+  ack_superseded_by?: AckSupersedeReason
 }
 
 export interface AssetStatus {


### PR DESCRIPTION
## Description

Update the command-ack model, API and UI to the final FSS v2 enums:

- ack_state gains noop (4) for a command that resolves to the already-current state, shown as "✓ no change" so it doesn't look like a phantom transition.
- ack_superseded_by is now a dedicated supersede *reason* (fss_command_ack_reason: none/low_battery/comms_loss), not a command value, so low-battery RTL and comms-loss RTL stay distinguishable. The API emits the reason as a code string and the UI renders "✗ superseded by low-battery RTL" / "comms-loss RTL", delivering feature-01's requirement.

The column types are unchanged; only the choices metadata moves, folded into migration 0008 (not yet released) rather than adding a no-op migration.

## Summary by Sourcery

Align command acknowledgement states and supersede reasons with the updated FSS v2 enums across backend and frontend.

New Features:
- Introduce a 'noop' command acknowledgement state to represent commands that resolve to the already-current asset state.
- Expose machine-readable supersede reasons for commands, distinguishing low-battery and comms-loss failsafe latches in the API and UI.

Enhancements:
- Map supersede reasons to human-friendly labels in the frontend and show them alongside superseded acknowledgements.
- Style noop acknowledgements consistently with successful actioned acknowledgements and update type definitions to carry the new enums.

Tests:
- Extend asset status JSON tests to cover the new noop acknowledgement state and the string-based supersede reason codes.