### PR TITLE
fix(frontend): time out stalled 'received' command acks

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -291,15 +291,28 @@ const supersedeReasonLabel: Record<AckSupersedeReason, string> = {
   comms_loss: 'comms-loss RTL'
 }
 
+// Age (ms) of a command's most recent acknowledgement activity. Prefers the
+// FMU-stamped ack_timestamp (wall-clock epoch-ms) when a phase-1 ack has been
+// recorded, otherwise falls back to when the command was dispatched.
+const commandAckAge = (command: AssetCommandData): number => {
+  const basis = command.ack_timestamp ?? new Date(command.timestamp).getTime()
+  return new Date().getTime() - basis
+}
+
 // Render the acknowledgement state of a command as a short suffix plus a CSS
-// class for styling. A 'pending' ack that has outlived commandAckTimeout is
-// reported distinctly ('no ack') so an ack that never arrives is visible
-// rather than looking like it is still in flight.
+// class for styling. An ack that has outlived commandAckTimeout is reported
+// distinctly ('no ack') so an ack that never arrives is visible rather than
+// looking like it is still in flight. This covers both a 'pending' command
+// that was never acknowledged at all and a 'received' command whose terminal
+// (actioned/superseded/…) ack never followed the phase-1 ack.
 const commandAckDisplay = (command: AssetCommandData): { text: string; className: string } => {
   switch (command.ack_state) {
     case 'actioned':
       return { text: '✓ actioned', className: 'asset-command-ack-actioned' }
     case 'received':
+      if (commandAckAge(command) > commandAckTimeout) {
+        return { text: '⚠ no ack', className: 'asset-command-ack-missing' }
+      }
       return { text: '… received', className: 'asset-command-ack-received' }
     case 'noop':
       return { text: '✓ no change', className: 'asset-command-ack-noop' }
@@ -310,13 +323,11 @@ const commandAckDisplay = (command: AssetCommandData): { text: string; className
     case 'rejected':
       return { text: '✗ rejected', className: 'asset-command-ack-rejected' }
     case 'pending':
-    default: {
-      const age = new Date().getTime() - new Date(command.timestamp).getTime()
-      if (age > commandAckTimeout) {
+    default:
+      if (commandAckAge(command) > commandAckTimeout) {
         return { text: '⚠ no ack', className: 'asset-command-ack-missing' }
       }
       return { text: '… awaiting ack', className: 'asset-command-ack-pending' }
-    }
   }
 }
 


### PR DESCRIPTION
## Description

A command stuck in 'received' (phase-1 ack arrived but the terminal actioned/superseded/... ack never followed) previously showed '… received' indefinitely, partly missing feature-01's requirement that pending acks which never arrive be visibly distinct.

Apply the existing commandAckTimeout check to a 'received' ack too: once it outlives the timeout it renders as '⚠ no ack' with the distinct asset-command-ack-missing style, matching the stalled-'pending' case. The received-age basis prefers the FMU-stamped ack_timestamp and falls back to the dispatch timestamp.

## Summary by Sourcery

Ensure stalled command acknowledgements in the frontend UI are surfaced consistently when they time out.

Bug Fixes:
- Treat commands stuck in the 'received' state past the acknowledgement timeout as missing a terminal ack and display them as '⚠ no ack'.

Enhancements:
- Centralize command acknowledgement age calculation into a reusable helper shared by both 'pending' and 'received' states.