### PR TITLE
feat(assets): add 'newer command' supersede reason

### DIFF
--- a/assets/migrations/0008_assetcommand_ack_state_and_more.py
+++ b/assets/migrations/0008_assetcommand_ack_state_and_more.py
@@ -34,6 +34,7 @@ class Migration(migrations.Migration):
                     (0, "None"),
                     (1, "Low Battery"),
                     (2, "Comms Loss"),
+                    (3, "Newer Command"),
                 ],
                 null=True,
             ),

--- a/assets/models.py
+++ b/assets/models.py
@@ -135,10 +135,12 @@ class AssetCommand(models.Model):
     SUPERSEDE_NONE = 0
     SUPERSEDE_LOW_BATTERY = 1
     SUPERSEDE_COMMS_LOSS = 2
+    SUPERSEDE_NEWER_COMMAND = 3
     SUPERSEDE_REASON_CHOICES = (
         (SUPERSEDE_NONE, "None"),
         (SUPERSEDE_LOW_BATTERY, "Low Battery"),
         (SUPERSEDE_COMMS_LOSS, "Comms Loss"),
+        (SUPERSEDE_NEWER_COMMAND, "Newer Command"),
     )
     dispatch_id = models.BigIntegerField(null=True, blank=True)
     ack_state = models.SmallIntegerField(null=True, blank=True, choices=ACK_STATE_CHOICES)

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -197,6 +197,20 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['command']['ack_state'], 'superseded')
         self.assertEqual(data['command']['ack_superseded_by'], 'low_battery')
 
+    def test_asset_status_json_ack_superseded_newer_command(self):
+        """A command superseded by a newer command reports that reason code."""
+        self.client.force_login(self.user)
+        AssetCommand.objects.create(
+            asset=self.asset, command='MAN',
+            ack_state=AssetCommand.ACK_SUPERSEDED,
+            ack_superseded_by=AssetCommand.SUPERSEDE_NEWER_COMMAND,
+        )
+        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        response = self.client.get(url)
+        data = response.json()
+        self.assertEqual(data['command']['ack_state'], 'superseded')
+        self.assertEqual(data['command']['ack_superseded_by'], 'newer_command')
+
     def test_asset_status_json_ack_noop(self):
         """A noop ack (already-current state) reports ack_state 'noop'."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -102,6 +102,7 @@ ACK_SUPERSEDE_REASON_CODES = {
     AssetCommand.SUPERSEDE_NONE: 'none',
     AssetCommand.SUPERSEDE_LOW_BATTERY: 'low_battery',
     AssetCommand.SUPERSEDE_COMMS_LOSS: 'comms_loss',
+    AssetCommand.SUPERSEDE_NEWER_COMMAND: 'newer_command',
 }
 
 

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -283,12 +283,14 @@ const dataAgeClass = (timestamp: string, old: number, warn: number, prefix: stri
   return ''
 }
 
-// Label for the failsafe latch that superseded a command. The latch always
-// engages an RTL, so name it as such for the operator.
+// Label for the reason a command was superseded. The failsafe latches always
+// engage an RTL, so name those as such for the operator; a newer command
+// simply overrides the older one and is not an RTL.
 const supersedeReasonLabel: Record<AckSupersedeReason, string> = {
   none: '',
   low_battery: 'low-battery RTL',
-  comms_loss: 'comms-loss RTL'
+  comms_loss: 'comms-loss RTL',
+  newer_command: 'newer command'
 }
 
 // Age (ms) of a command's most recent acknowledgement activity. Prefers the

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -28,7 +28,7 @@ export interface AssetRTTData {
 }
 
 export type AckState = 'pending' | 'received' | 'actioned' | 'superseded' | 'rejected' | 'noop'
-export type AckSupersedeReason = 'none' | 'low_battery' | 'comms_loss'
+export type AckSupersedeReason = 'none' | 'low_battery' | 'comms_loss' | 'newer_command'
 
 export interface AssetCommandData {
   timestamp: string


### PR DESCRIPTION
## Description

Mirror FSS's new fss_command_ack_reason value supersede_newer_command (= 3): a command that was overridden by a newer command. Unlike the low-battery/comms-loss latches, this is not an RTL, so the operator UI reads "superseded by newer command" rather than a bare "superseded".

Adds SUPERSEDE_NEWER_COMMAND to AssetCommand and the supersede choices (folded into the unreleased migration 0008 — makemigrations stays clean), the 'newer_command' code in the status API, and the matching AckSupersedeReason type + label in the frontend.

## Summary by Sourcery

Add explicit support for the "superseded by newer command" acknowledgement reason across asset commands, APIs, and frontend display.

New Features:
- Expose a new AssetCommand supersede reason representing commands overridden by a newer command in the model, API payload, and frontend types.

Tests:
- Add a backend test ensuring the asset status JSON reports the new "newer_command" supersede reason correctly.