### PR TITLE
perf(frontend): use Date.now() for command-ack age

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -298,7 +298,7 @@ const supersedeReasonLabel: Record<AckSupersedeReason, string> = {
 // recorded, otherwise falls back to when the command was dispatched.
 const commandAckAge = (command: AssetCommandData): number => {
   const basis = command.ack_timestamp ?? new Date(command.timestamp).getTime()
-  return new Date().getTime() - basis
+  return Date.now() - basis
 }
 
 // Render the acknowledgement state of a command as a short suffix plus a CSS


### PR DESCRIPTION
## Description

Address Sourcery review on PR #640: avoid allocating a throwaway Date instance for the current time when computing ack age.

## Summary by Sourcery

Use Date.now() instead of allocating a new Date instance when computing command acknowledgement age to reduce unnecessary object allocations and improve frontend performance.