### PR TITLE
fix(frontend): age command acks on a single server clock

### DIFF
--- a/assets/views.py
+++ b/assets/views.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
+from django.utils import timezone
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from fss.decorators import login_required_api
@@ -16,6 +17,17 @@ from fss.decorators import login_required_api
 from .models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
 
 RTT_SAMPLE_LIMIT = 15
+
+
+def server_now_ms():
+    """
+    The server's current time as epoch milliseconds.
+
+    Emitted alongside status data so the frontend can age commands against a
+    single server clock (server_now - command.timestamp) rather than mixing the
+    browser clock with server/FMU timestamps, which clock skew would corrupt.
+    """
+    return int(timezone.now().timestamp() * 1000)
 
 
 @ensure_csrf_cookie

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -11,6 +11,9 @@ export interface AssetServerState {
   serverName: string
   assetPk: number
   data?: AssetStatus
+  // The server's current time (epoch-ms) from the poll that produced `data`.
+  // Lets command ages be computed against this server's clock alone.
+  serverNow?: number
 }
 
 export interface AssetState {
@@ -76,7 +79,7 @@ export const assetPositionMostRecent = (asset: AssetState): AssetPositionData | 
   return best
 }
 
-export const mergeServerAssets = (currentAssets: Record<string, AssetState>, serverName: string, assets: AssetStatus[]): Record<string, AssetState> => {
+export const mergeServerAssets = (currentAssets: Record<string, AssetState>, serverName: string, assets: AssetStatus[], serverNow?: number): Record<string, AssetState> => {
   const nextAssets = { ...currentAssets }
   for (const assetData of assets) {
     const assetName = assetData.asset.name
@@ -84,7 +87,8 @@ export const mergeServerAssets = (currentAssets: Record<string, AssetState>, ser
     const assetServer: AssetServerState = {
       serverName,
       assetPk: assetData.asset.pk,
-      data: assetData
+      data: assetData,
+      serverNow
     }
     nextAssets[assetName] = {
       ...existing,

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -293,12 +293,17 @@ const supersedeReasonLabel: Record<AckSupersedeReason, string> = {
   newer_command: 'newer command'
 }
 
-// Age (ms) of a command's most recent acknowledgement activity. Prefers the
-// FMU-stamped ack_timestamp (wall-clock epoch-ms) when a phase-1 ack has been
-// recorded, otherwise falls back to when the command was dispatched.
-const commandAckAge = (command: AssetCommandData): number => {
-  const basis = command.ack_timestamp ?? new Date(command.timestamp).getTime()
-  return Date.now() - basis
+// Age (ms) of a command since it was dispatched, measured entirely on the
+// server's clock: serverNow (epoch-ms from the same poll) minus the command's
+// dispatch timestamp. This deliberately avoids the browser clock and the
+// FMU-stamped ack_timestamp — mixing clocks lets skew (corrected elsewhere via
+// RTT offset) produce a false 'no ack' or a timeout that never fires. When the
+// server clock is unavailable, fall back to the browser clock so a missing
+// ack still eventually surfaces rather than appearing stuck forever.
+const commandAckAge = (command: AssetCommandData, serverNow?: number): number => {
+  const dispatched = new Date(command.timestamp).getTime()
+  const now = serverNow ?? Date.now()
+  return now - dispatched
 }
 
 // Render the acknowledgement state of a command as a short suffix plus a CSS
@@ -307,12 +312,12 @@ const commandAckAge = (command: AssetCommandData): number => {
 // looking like it is still in flight. This covers both a 'pending' command
 // that was never acknowledged at all and a 'received' command whose terminal
 // (actioned/superseded/…) ack never followed the phase-1 ack.
-const commandAckDisplay = (command: AssetCommandData): { text: string; className: string } => {
+const commandAckDisplay = (command: AssetCommandData, serverNow?: number): { text: string; className: string } => {
   switch (command.ack_state) {
     case 'actioned':
       return { text: '✓ actioned', className: 'asset-command-ack-actioned' }
     case 'received':
-      if (commandAckAge(command) > commandAckTimeout) {
+      if (commandAckAge(command, serverNow) > commandAckTimeout) {
         return { text: '⚠ no ack', className: 'asset-command-ack-missing' }
       }
       return { text: '… received', className: 'asset-command-ack-received' }
@@ -326,7 +331,7 @@ const commandAckDisplay = (command: AssetCommandData): { text: string; className
       return { text: '✗ rejected', className: 'asset-command-ack-rejected' }
     case 'pending':
     default:
-      if (commandAckAge(command) > commandAckTimeout) {
+      if (commandAckAge(command, serverNow) > commandAckTimeout) {
         return { text: '⚠ no ack', className: 'asset-command-ack-missing' }
       }
       return { text: '… awaiting ack', className: 'asset-command-ack-pending' }
@@ -442,7 +447,7 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
       text += ` to ${data.command.alt}ft`
     }
     commandTxt = data.command.command_code === 'MAN' ? <strong>Take Manual Control Now</strong> : text
-    const ack = commandAckDisplay(data.command)
+    const ack = commandAckDisplay(data.command, server.serverNow)
     commandAck = <span className={'asset-status-command-ack ' + ack.className}> {ack.text}</span>
   }
   return (
@@ -615,7 +620,7 @@ export const FSSMainPage: React.FC = () => {
         }
       } else {
         currentServers = mergeServerPollResult(currentServers, serverName, data)
-        currentAssets = mergeServerAssets(currentAssets, serverName, data.assets)
+        currentAssets = mergeServerAssets(currentAssets, serverName, data.assets, data.server_now)
       }
     }
 

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -70,6 +70,10 @@ export interface ServerDetails {
 export interface StatusData {
   currentUser?: string
   csrfToken: string
+  // The server's current time (epoch-ms) when this status was produced. Used to
+  // age commands against a single server clock rather than the browser clock,
+  // which clock skew (corrected elsewhere via RTT offset) would corrupt.
+  server_now?: number
   servers: Array<ServerDetails>
   assets: Array<AssetStatus>
 }

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetStatus
 from config.models import ServerConfig
@@ -39,6 +40,19 @@ class StatusAPITest(TestCase):
         self.assertEqual(len(data['assets']), 1)
         self.assertEqual(data['assets'][0]['asset']['name'], 'Test Drone')
         self.assertIn('csrfToken', data)
+
+    def test_all_status_data_server_now(self):
+        """The status response carries the server's current time (epoch-ms)."""
+        self.client.login(username='testuser', password='password')
+        url = reverse('all_status_data')
+        before = int(timezone.now().timestamp() * 1000)
+        response = self.client.get(url)
+        after = int(timezone.now().timestamp() * 1000)
+        data = response.json()
+        self.assertIn('server_now', data)
+        self.assertIsInstance(data['server_now'], int)
+        self.assertGreaterEqual(data['server_now'], before)
+        self.assertLessEqual(data['server_now'], after)
 
     def test_all_status_data_with_details(self):
         """Test with position and status data."""

--- a/main/views.py
+++ b/main/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from assets.models import Asset
-from assets.views import bulk_asset_status_data
+from assets.views import bulk_asset_status_data, server_now_ms
 from config.models import ServerConfig
 from fss.decorators import login_required_api
 
@@ -83,6 +83,9 @@ def all_status_data(request):
     data = {
         'currentUser': None,
         'csrfToken': get_token(request),
+        # The server's current time (epoch-ms), used by the frontend to age
+        # commands against a single server clock instead of the browser clock.
+        'server_now': server_now_ms(),
         'servers': [],
         'assets': []
     }


### PR DESCRIPTION
## Description

The 15s 'no ack' timeout aged commands with Date.now() (browser clock) against the FMU/server timestamps, so client clock skew (corrected elsewhere via RTT offset) could produce a false '⚠ no ack' or a timeout that never fires. Emit the server's current epoch-ms (server_now) from the status view and age commands as server_now - command.timestamp, both on the server clock; drop ack_timestamp as the timeout basis.

## Summary by Sourcery

Age frontend command acknowledgements using a server-provided timestamp to avoid browser/server clock skew and expose that server time through the status API.

Bug Fixes:
- Prevent false or missing command ack timeouts by basing ack age calculations on a single server clock instead of mixing browser and FMU/server timestamps.

Enhancements:
- Propagate the server's current epoch-millisecond time through status responses and asset state so the frontend can compute command ages consistently.

Tests:
- Add a view test asserting that status responses include a bounded server_now timestamp field.