### PR TITLE
feat(frontend): flag cross-server command/ack misalignment

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -362,6 +362,109 @@ const commandAckDisplay = (command: AssetCommandData, serverNow?: number): { tex
   }
 }
 
+// A stable category for a command's acknowledgement outcome, used to compare
+// servers against each other. Unlike commandAckDisplay's text this collapses the
+// transient in-flight phases (pending/received before the timeout) into a single
+// 'in-flight' bucket so two servers a poll apart aren't flagged as disagreeing
+// over normal latency. A timed-out pending becomes 'no-ack', a timed-out
+// received becomes 'received-stalled', and an RTL kept in effect by a failsafe
+// latch is treated as actioned (it is doing what was asked).
+type AckOutcome = 'actioned' | 'noop' | 'in-flight' | 'no-ack' | 'received-stalled' | 'superseded' | 'rejected'
+
+const commandAckOutcome = (command: AssetCommandData, serverNow?: number): AckOutcome => {
+  switch (command.ack_state) {
+    case 'actioned':
+      return 'actioned'
+    case 'noop':
+      return 'noop'
+    case 'rejected':
+      return 'rejected'
+    case 'superseded':
+      return supersededRtlInEffect(command) ? 'actioned' : 'superseded'
+    case 'received':
+      return commandAckAge(command, serverNow) > commandAckTimeout ? 'received-stalled' : 'in-flight'
+    case 'pending':
+    default:
+      return commandAckAge(command, serverNow) > commandAckTimeout ? 'no-ack' : 'in-flight'
+  }
+}
+
+// Per-server view of an asset's command, for the misalignment indicator.
+interface ServerCommandView {
+  serverName: string
+  commandCode?: string
+  ack: { text: string; className: string }
+  outcome?: AckOutcome
+}
+
+// Compare what each of an asset's servers believes about its current command.
+// Servers "disagree" when they hold different command_codes (the operator's
+// command didn't reach all of them, or they hold different/stale commands) OR
+// when they hold the same command but report divergent ack outcomes (e.g.
+// actioned on one, no-ack/superseded/rejected on another). Servers without
+// command data are ignored. Returns the per-server breakdown plus whether the
+// servers that DO have a command disagree; with fewer than two such servers
+// there is nothing to disagree about.
+const assetServerMisalignment = (asset: AssetState): { disagree: boolean; servers: ServerCommandView[] } => {
+  const servers: ServerCommandView[] = []
+  for (const assetServer of Object.values(asset.servers)) {
+    const command = assetServer.data?.command
+    if (!command) continue
+    servers.push({
+      serverName: assetServer.serverName,
+      commandCode: command.command_code,
+      ack: commandAckDisplay(command, assetServer.serverNow),
+      outcome: commandAckOutcome(command, assetServer.serverNow)
+    })
+  }
+  let disagree = false
+  if (servers.length > 1) {
+    const codes = new Set(servers.map((s) => s.commandCode))
+    const outcomes = new Set(servers.map((s) => s.outcome))
+    disagree = codes.size > 1 || outcomes.size > 1
+  }
+  return { disagree, servers }
+}
+
+// Asset-level banner shown when an asset's servers disagree about its command.
+// Surfaces a split that is otherwise buried in the separate per-server tabs:
+// the operator can see at a glance that the servers are out of step and, by
+// expanding, exactly which server differs and how.
+const FSSAssetCommandMisalignment: React.FC<{ asset: AssetState }> = ({ asset }) => {
+  const [expanded, setExpanded] = useState(false)
+  const { disagree, servers } = assetServerMisalignment(asset)
+  if (!disagree) {
+    return null
+  }
+  return (
+    <div className="asset-command-misalignment">
+      <button type="button" className="asset-command-misalignment-badge" onClick={() => setExpanded((e) => !e)} aria-expanded={expanded}>
+        ⚠ servers disagree {expanded ? '▾' : '▸'}
+      </button>
+      {expanded && (
+        <table className="asset-command-misalignment-detail">
+          <thead>
+            <tr>
+              <td>Server</td>
+              <td>Command</td>
+              <td>Ack</td>
+            </tr>
+          </thead>
+          <tbody>
+            {servers.map((s) => (
+              <tr key={s.serverName}>
+                <td>{s.serverName}</td>
+                <td>{s.commandCode ?? '—'}</td>
+                <td className={s.ack.className}>{s.ack.text}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
 const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: string }> = ({ server, serverLabel }) => {
   const { data } = server
   let rttTable
@@ -503,6 +606,7 @@ const FSSAssetStatus: React.FC<FSSAssetStatusProps> = ({ asset, setSelected }) =
 
   return (
     <div className="container card">
+      <FSSAssetCommandMisalignment asset={asset} />
       <ul className="nav nav-tabs server-tab-btn">
         {assetServers.map((server) => (
           <li className="nav-item" key={server.serverName}>

--- a/frontend/fssweb.css
+++ b/frontend/fssweb.css
@@ -120,3 +120,25 @@ div.server-label-connected {
   color: orange;
   font-weight: bold;
 }
+
+/* Asset-level warning that the servers disagree about the current command. */
+.asset-command-misalignment {
+  text-align: center;
+}
+
+.asset-command-misalignment-badge {
+  border: none;
+  background: none;
+  color: red;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.asset-command-misalignment-detail {
+  margin: 0 auto;
+  font-size: smaller;
+}
+
+.asset-command-misalignment-detail td {
+  padding: 0 0.5em;
+}


### PR DESCRIPTION
## Description

An asset's servers each hold their own view of its current command. When they diverge — different command_codes (the command didn't reach all servers, or they hold stale commands) or the same command with different ack outcomes (actioned on one, no-ack/superseded/rejected on another) — that split was previously buried in the separate per-server tabs.

Add an asset-level '⚠ servers disagree' banner, expandable to a table of each server's command + ack-state so the operator can see which server differs. Computed client-side from the merged per-server data; outcomes are bucketed (in-flight phases collapsed) so normal poll-to-poll latency between servers isn't flagged as disagreement.

## Summary by Sourcery

Add an asset-level warning banner and details view when servers disagree about an asset's current command or its acknowledgement outcome.

New Features:
- Show an asset-level banner indicating when servers hold divergent command codes or acknowledgement outcomes for the same asset.
- Provide an expandable per-server table summarizing each server's command code and acknowledgement state when misalignment is detected.

Enhancements:
- Normalize command acknowledgement outcomes into stable buckets to avoid flagging transient in-flight latency differences as disagreements.