### PR TITLE
fix(settings): don't swallow import errors inside local_settings

### DIFF
--- a/fss/settings.py
+++ b/fss/settings.py
@@ -18,8 +18,13 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 try:
     # pylint: disable=W0401,W0614
     from fss.local_settings import *
-except ImportError:
-    pass
+except ModuleNotFoundError as exc:
+    # Only tolerate a genuinely-absent local_settings. A ModuleNotFoundError
+    # raised by a bad import *inside* local_settings names that other module,
+    # not fss.local_settings; re-raise it rather than booting with a half-built
+    # configuration (e.g. no DATABASES) and a confusing downstream failure.
+    if exc.name != 'fss.local_settings':
+        raise
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
## Description

The bare `except ImportError: pass` around the local_settings import hid not just an absent file but a real bad import *inside* local_settings, booting the app with no DATABASES and failing far from the cause. Narrow the handler to ModuleNotFoundError for fss.local_settings itself and re-raise anything else.

## Summary by Sourcery

Bug Fixes:
- Prevent local_settings import handler from swallowing real import errors inside local_settings that led to misconfigured application state.