### PR TITLE
fix(login): don't 500 on a POST with missing credentials

### DIFF
--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -150,3 +150,9 @@ class StatusAPITest(TestCase):
         url = reverse('login_page')
         response = self.client.post(url, {'username': 'testuser', 'password': 'password'})
         self.assertRedirects(response, '/')
+
+    def test_login_page_post_missing_credentials(self):
+        """A POST with no credentials fails cleanly rather than 500ing."""
+        url = reverse('login_page')
+        response = self.client.post(url, {})
+        self.assertRedirects(response, '/login/?error=1', target_status_code=200)

--- a/main/views.py
+++ b/main/views.py
@@ -64,8 +64,8 @@ def login_page(request):
     Login a user
     """
     if request.method == "POST":
-        username = request.POST['username']
-        password = request.POST['password']
+        username = request.POST.get('username')
+        password = request.POST.get('password')
         user = authenticate(request, username=username, password=password)
         if user is not None:
             login(request, user)


### PR DESCRIPTION
## Description

login_page read request.POST['username']/['password'] with subscript access, so a POST omitting either field raised KeyError -> HTTP 500 instead of a clean failed-login redirect. Use .get() and let authenticate() reject the None, redirecting to /login/?error=1.

## Summary by Sourcery

Handle login POSTs with missing credentials without causing server errors.

Bug Fixes:
- Prevent login_page view from raising a KeyError when username or password is omitted in POST data, returning the standard failed-login redirect instead.

Tests:
- Add regression test ensuring login POSTs with missing credentials result in a clean redirect to the login page with an error flag.