### PR TITLE
refactor(login): simplify CSRF cookie parsing

### DIFF
--- a/frontend/login-page.tsx
+++ b/frontend/login-page.tsx
@@ -8,11 +8,13 @@ export const LoginPage: React.FC = () => {
   const hasError = searchParams.get('error') === '1'
 
   useEffect(() => {
-    // Read CSRF token from cookie. slice() (rather than split('=')) keeps any
-    // '=' that may appear within the value intact.
+    // Read CSRF token from cookie. Split on ';' and trim each segment so a
+    // missing space after the separator can't hide the cookie. slice() (rather
+    // than split('=')) keeps any '=' that may appear within the value intact.
     const prefix = 'csrftoken='
     const token = document.cookie
-      .split('; ')
+      .split(';')
+      .map((c) => c.trim())
       .find((c) => c.startsWith(prefix))
       ?.slice(prefix.length)
     setCsrfToken(token ?? '')

--- a/frontend/login-page.tsx
+++ b/frontend/login-page.tsx
@@ -8,20 +8,14 @@ export const LoginPage: React.FC = () => {
   const hasError = searchParams.get('error') === '1'
 
   useEffect(() => {
-    // Read CSRF token from cookie
-    const name = 'csrftoken='
-    const decodedCookie = decodeURIComponent(document.cookie)
-    const ca = decodedCookie.split(';')
-    for (let i = 0; i < ca.length; i++) {
-      let c = ca[i]
-      while (c.charAt(0) === ' ') {
-        c = c.substring(1)
-      }
-      if (c.indexOf(name) === 0) {
-        setCsrfToken(c.substring(name.length, c.length))
-        break
-      }
-    }
+    // Read CSRF token from cookie. slice() (rather than split('=')) keeps any
+    // '=' that may appear within the value intact.
+    const prefix = 'csrftoken='
+    const token = document.cookie
+      .split('; ')
+      .find((c) => c.startsWith(prefix))
+      ?.slice(prefix.length)
+    setCsrfToken(token ?? '')
   }, [])
 
   return (


### PR DESCRIPTION
## Description

Replace the character-by-character cookie loop with a split/find lookup. Using slice() rather than split('=') keeps any '=' within the token value intact.

## Summary by Sourcery

Enhancements:
- Refactor CSRF cookie parsing logic in the login page to use a more concise and robust split/find-based implementation.