### PR TITLE
refactor(routes): drop duplicate trailing-slash routes

### DIFF
--- a/frontend/main.tsx
+++ b/frontend/main.tsx
@@ -13,13 +13,12 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <Router>
     <Routes>
+      {/* React Router matches an optional trailing slash, so one route per
+          page covers both /login and /login/. */}
       <Route path="/" element={<FSSMainPage />} />
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/login/" element={<LoginPage />} />
       <Route path="/config" element={<ConfigPage />} />
-      <Route path="/config/" element={<ConfigPage />} />
       <Route path="/assets" element={<AssetListPage />} />
-      <Route path="/assets/" element={<AssetListPage />} />
     </Routes>
   </Router>
 )


### PR DESCRIPTION
## Description

React Router compiles non-wildcard paths with a trailing '\/*$', so a single route per page already matches both /login and /login/. Removes the manually-kept-in-sync duplicates.

## Summary by Sourcery

Consolidate React Router page routes by relying on optional trailing slash matching and remove redundant duplicate paths.

Enhancements:
- Remove duplicate trailing-slash route definitions now covered by React Router's optional trailing slash matching.
- Document in the router configuration that single routes handle both slash and non-slash URL variants.