### PR TITLE
fix(assets): asset list no longer fetches server topology

### DIFF
--- a/frontend/asset-list-page.tsx
+++ b/frontend/asset-list-page.tsx
@@ -13,7 +13,7 @@ export const AssetListPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    fetch('/config/status.json')
+    fetch('/assets.json')
       .then((r) => {
         if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
         return r.json()

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetStatus
-from config.models import ServerConfig
+from config.models import AssetConfig, ServerConfig, SMMConfig
 
 
 class StatusAPITest(TestCase):
@@ -128,7 +128,22 @@ class StatusAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data['assets']), 1)
-        self.assertEqual(data['assets'][0]['name'], 'Test Drone')
+        entry = data['assets'][0]
+        self.assertEqual(entry['name'], 'Test Drone')
+        # No AssetConfig for this asset, so SMM fields are null.
+        self.assertIsNone(entry['smm_name'])
+        self.assertIsNone(entry['smm_login'])
+
+    def test_asset_list_includes_smm_config(self):
+        """asset_list surfaces SMM name/login when an AssetConfig exists."""
+        smm = SMMConfig.objects.create(name='SMM Server', address='2.2.2.2', port=9090)
+        AssetConfig.objects.create(asset=self.asset, smm=smm, smm_login='operator', smm_password='secret')
+        self.client.login(username='testuser', password='password')
+        url = reverse('asset_list')
+        response = self.client.get(url)
+        entry = response.json()['assets'][0]
+        self.assertEqual(entry['smm_name'], 'SMM Server')
+        self.assertEqual(entry['smm_login'], 'operator')
 
     def test_main_view(self):
         """The landing page serves the React SPA and sets the CSRF cookie."""

--- a/main/views.py
+++ b/main/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 
 from assets.models import Asset
 from assets.views import bulk_asset_status_data, server_now_ms
-from config.models import ServerConfig
+from config.models import AssetConfig, ServerConfig
 from fss.decorators import login_required_api
 
 
@@ -45,8 +45,17 @@ def asset_list(request):
     """
     Return the know assets as a json array
     """
-    assets = Asset.objects.all()
-    assets_list = [{'pk': asset.pk, 'name': asset.name} for asset in assets]
+    assets = list(Asset.objects.all())
+    configs_by_asset_id = {c.asset_id: c for c in AssetConfig.objects.filter(asset__in=assets).select_related('smm')}
+    assets_list = []
+    for asset in assets:
+        config = configs_by_asset_id.get(asset.id)
+        assets_list.append({
+            'pk': asset.pk,
+            'name': asset.name,
+            'smm_name': config.smm.name if config else None,
+            'smm_login': config.smm_login if config else None,
+        })
     return JsonResponse({'assets': assets_list})
 
 


### PR DESCRIPTION
## Description

AssetListPage fetched /config/status.json and used only data.assets, exposing FSS/SMM server addresses to the list view. Point it at /assets.json instead, extended to carry smm_name/smm_login so the table still renders.

## Summary by Sourcery

Update asset list API and frontend to consume a dedicated assets endpoint while exposing limited SMM metadata per asset.

New Features:
- Expose SMM name and login fields on the asset list API when an asset has an associated SMM configuration.

Bug Fixes:
- Stop the asset list page from fetching server topology from the status configuration endpoint.

Tests:
- Add tests verifying that the asset list API includes SMM metadata when available and nulls when not.