### PR TITLE
Enforce frontend typechecking

### DIFF
--- a/frontend/assets.d.ts
+++ b/frontend/assets.d.ts
@@ -1,0 +1,6 @@
+declare module '*.css'
+
+declare module '*.png' {
+  const src: string
+  export default src
+}

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -1,4 +1,4 @@
-import { degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
+import { type Axis, degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
 import { AssetState, AssetServerState, AssetController, createAssetController, mergeServerAssets } from './asset'
 import {
   ServerState,
@@ -139,12 +139,12 @@ const Goto: React.FC<AssetProps> = ({ controller }) => {
 
   const handleGoto = (onClose: () => void) => command(() => controller.Goto(position!.lat, position!.lng), onClose)
 
-  const handlePositionChange = (event: React.ChangeEvent<HTMLInputElement>, isLat: boolean) => {
+  const handlePositionChange = (event: React.ChangeEvent<HTMLInputElement>, axis: Axis) => {
     const { value } = event.target
     const positionValue = DMToDegrees(value)
     setPosition((prev) => {
       const current = prev || getDefaultPosition()
-      return { ...current, [isLat ? 'lat' : 'lng']: positionValue }
+      return { ...current, [axis === 'lat' ? 'lat' : 'lng']: positionValue }
     })
   }
 
@@ -167,8 +167,8 @@ const Goto: React.FC<AssetProps> = ({ controller }) => {
       title={<>Send {controller.name} to:</>}
       body={
         <>
-          <input type="text" value={degreesToDM(pos.lat, 'lat')} onChange={(e) => handlePositionChange(e, true)}></input>
-          <input type="text" value={degreesToDM(pos.lng, 'lon')} onChange={(e) => handlePositionChange(e, false)}></input>
+          <input type="text" value={degreesToDM(pos.lat, 'lat')} onChange={(e) => handlePositionChange(e, 'lat')}></input>
+          <input type="text" value={degreesToDM(pos.lng, 'lon')} onChange={(e) => handlePositionChange(e, 'lon')}></input>
           <MapContainer center={pos} zoom={13} className="dialog-map">
             <TileLayer
               attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -167,8 +167,8 @@ const Goto: React.FC<AssetProps> = ({ controller }) => {
       title={<>Send {controller.name} to:</>}
       body={
         <>
-          <input type="text" value={degreesToDM(pos.lat, true)} onChange={(e) => handlePositionChange(e, true)}></input>
-          <input type="text" value={degreesToDM(pos.lng, false)} onChange={(e) => handlePositionChange(e, false)}></input>
+          <input type="text" value={degreesToDM(pos.lat, 'lat')} onChange={(e) => handlePositionChange(e, true)}></input>
+          <input type="text" value={degreesToDM(pos.lng, 'lon')} onChange={(e) => handlePositionChange(e, false)}></input>
           <MapContainer center={pos} zoom={13} className="dialog-map">
             <TileLayer
               attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -503,8 +503,8 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
         </thead>
         <tbody>
           <tr>
-            <td>{degreesToDM(data.position.lat, true)}</td>
-            <td>{degreesToDM(data.position.lng, false)}</td>
+            <td>{degreesToDM(data.position.lat, 'lat')}</td>
+            <td>{degreesToDM(data.position.lng, 'lon')}</td>
             <td>{data.position.alt ?? 'N/A'}</td>
           </tr>
         </tbody>
@@ -567,7 +567,7 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
     let text = data.command.command
     if (data.command.command_code === 'GOTO') {
       if (data.command.lat && data.command.lng) {
-        text += ` ${degreesToDM(data.command.lat, true)}, ${degreesToDM(data.command.lng, false)}`
+        text += ` ${degreesToDM(data.command.lat, 'lat')}, ${degreesToDM(data.command.lng, 'lon')}`
       }
     }
     if (data.command.command_code === 'ALT') {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "frontend/main.js",
   "scripts": {
-    "check": "eslint frontend/ && prettier -c frontend/",
+    "check": "tsc --noEmit && eslint frontend/ && prettier -c frontend/",
     "build-only": "esbuild $(esbuild-config)",
     "build": "esbuild $(esbuild-config)",
     "test": "vitest run"


### PR DESCRIPTION
## Summary by Sourcery

Enforce TypeScript type checking for the frontend build and adjust related code to satisfy new type constraints.

Enhancements:
- Update degrees-to-DM formatting calls to use explicit latitude/longitude identifiers instead of booleans for improved type safety.
- Add TypeScript declaration file for CSS and PNG asset imports in the frontend.

Build:
- Add TypeScript compiler check to the frontend `check` npm script.