### PR TITLE
Default cookies to secure settings

### DIFF
--- a/fss/settings.py
+++ b/fss/settings.py
@@ -26,6 +26,14 @@ except ModuleNotFoundError as exc:
     if exc.name != 'fss.local_settings':
         raise
 
+# Secure-by-default cookie posture. Site-specific settings may deliberately
+# override these for local HTTP development, but production should not depend on
+# each install having copied the latest local_settings.py template.
+globals().setdefault('SESSION_COOKIE_SECURE', True)
+globals().setdefault('CSRF_COOKIE_SECURE', True)
+globals().setdefault('SESSION_COOKIE_SAMESITE', 'Lax')
+globals().setdefault('CSRF_COOKIE_SAMESITE', 'Lax')
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/

--- a/main/tests/test_security_settings.py
+++ b/main/tests/test_security_settings.py
@@ -1,0 +1,21 @@
+"""
+Tests for security-relevant Django settings.
+"""
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+
+class SecuritySettingsTest(SimpleTestCase):
+    """
+    Check base security defaults that local deployments inherit.
+    """
+
+    def test_secure_cookie_defaults_are_enabled(self):
+        """
+        Session and CSRF cookies default to HTTPS-only with SameSite=Lax.
+        """
+        self.assertTrue(settings.SESSION_COOKIE_SECURE)
+        self.assertTrue(settings.CSRF_COOKIE_SECURE)
+        self.assertEqual(settings.SESSION_COOKIE_SAMESITE, 'Lax')
+        self.assertEqual(settings.CSRF_COOKIE_SAMESITE, 'Lax')


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add tests verifying secure defaults for session and CSRF cookie settings, including SameSite=Lax.