### PR TITLE
build(frontend): align tsconfig module resolution with esbuild, pin eslint react version

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import pluginReact from "eslint-plugin-react";
 export default [
   {files: ["**/*.{js,mjs,cjs,jsx}"]},
   {languageOptions: { globals: globals.browser }},
+  {settings: { react: { version: "detect" } }},
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "esnext",                                  /* ESM to match the esbuild bundle; type-check only (esbuild does the emit). */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",                       /* Resolve modules the way esbuild does (package.json "exports"), so tsc and the bundler agree. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Description

tsc type-checked with module=commonjs / default (node10) resolution while esbuild bundles as ESM with bundler-style resolution, so the two could disagree on package.json "exports" lookups. Switch tsconfig to module=esnext + moduleResolution=bundler (type-check only; esbuild still does the emit) so the checker resolves the way the bundler does.

Also pin eslint-plugin-react to version=detect to silence the unspecified-React -version warning.

No behaviour change: tsc --noEmit, eslint, prettier, vitest (13/13) and the esbuild build all pass.

## Summary by Sourcery

Align TypeScript module settings with the esbuild bundler and configure ESLint React plugin version detection.

Bug Fixes:
- Ensure TypeScript type-checking resolves modules consistently with esbuild, avoiding mismatches around package.json export resolution.

Enhancements:
- Configure ESLint React settings to detect the React version automatically, silencing related warnings.

Build:
- Update tsconfig to use ESNext modules and bundler-style module resolution to match esbuild behavior.