### PR TITLE
fix(assets): stop asset_add racing on duplicate names

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -92,6 +92,14 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content.decode(), 'Asset already exists')
 
+    def test_asset_add_missing_name(self):
+        """Test that a POST with no asset_name is rejected with its own message."""
+        self.client.force_login(self.user)
+        url = reverse('asset_add')
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content.decode(), 'Missing asset_name')
+
     def test_asset_command_set_invalid_command(self):
         """Test that an unrecognised command is rejected."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -6,6 +6,7 @@ import contextlib
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import IntegrityError
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -359,12 +360,16 @@ def asset_add(request):
     """
     Add an asset
     """
-    if request.method == "POST":
-        asset_name = request.POST.get('asset_name')
-        if asset_name is not None:
-            if Asset.objects.filter(name=asset_name).exists():
-                return HttpResponse("Asset already exists", status=409)
-            asset = Asset(name=asset_name)
-            asset.save()
-            return HttpResponse("Created")
-    return HttpResponseBadRequest("Only POST is supported")
+    if request.method != "POST":
+        return HttpResponseBadRequest("Only POST is supported")
+    asset_name = request.POST.get('asset_name')
+    if asset_name is None:
+        return HttpResponseBadRequest("Missing asset_name")
+    try:
+        Asset.objects.create(name=asset_name)
+    except IntegrityError:
+        # Relies on Asset.name's unique constraint rather than a racy
+        # exists()-then-save() check, so two concurrent requests for the same
+        # name both get the clean 409 instead of one raising an unhandled 500.
+        return HttpResponse("Asset already exists", status=409)
+    return HttpResponse("Created")


### PR DESCRIPTION
## Description

Rely on Asset.name's unique constraint (IntegrityError -> 409) instead of a check-then-act exists()/save(), which could 500 under concurrent requests for the same name. Also give the missing-asset_name case its own 400 message instead of reusing "Only POST is supported".

## Summary by Sourcery

Handle asset creation using database-level uniqueness and clearer request validation.

Bug Fixes:
- Prevent race conditions on asset creation by relying on the Asset.name unique constraint and handling IntegrityError as a 409 response.
- Return a specific 400 error when asset_name is missing instead of a generic method error.

Tests:
- Add a test verifying a 400 response and specific message when asset_name is omitted in POST requests to asset_add.