### PR TITLE
fix(assets): align altitude ceiling across frontend and backend

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -110,6 +110,7 @@ class AssetCommand(models.Model):
     REQUIRES_POSITION = ('GOTO', )
     position = models.PointField(geography=True, null=True, blank=True)
     REQUIRES_ALTITUDE = ('ALT', )
+    ALTITUDE_MAX_FT = 999
     altitude = models.IntegerField(null=True, blank=True)
 
     # Who dispatched this command, recorded for the audit trail of a

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -116,6 +116,14 @@ class AssetAPITest(TestCase):
         response = self.client.post(url, {'command': 'ALT', 'altitude': 1001})
         self.assertEqual(response.status_code, 400)
 
+        # AssetCommand.ALTITUDE_MAX_FT is the shared ceiling with the frontend's
+        # max="999" input; 1000 must be rejected so the two layers cannot drift.
+        response = self.client.post(url, {'command': 'ALT', 'altitude': 1000})
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.post(url, {'command': 'ALT', 'altitude': 999})
+        self.assertEqual(response.status_code, 200)
+
         response = self.client.post(url, {'command': 'ALT', 'altitude': -1})
         self.assertEqual(response.status_code, 400)
 

--- a/assets/views.py
+++ b/assets/views.py
@@ -339,7 +339,7 @@ def asset_command_set(request, asset_id):
         if command in AssetCommand.REQUIRES_ALTITUDE:
             try:
                 altitude = int(request.POST.get('altitude'))
-                if altitude < 0 or altitude > 1000:
+                if altitude < 0 or altitude > AssetCommand.ALTITUDE_MAX_FT:
                     raise ValueError
             except (ValueError, TypeError):
                 return HttpResponseBadRequest('Invalid Altitude')


### PR DESCRIPTION
## Description

The backend accepted altitude up to 1000 while the frontend input caps at 999 and the CHANGELOG documents a 0-999 range. Define AssetCommand.ALTITUDE_MAX_FT = 999 as the single source of truth and check against it, so the two layers can't drift again. Pin the exact ceiling (999 accepted, 1000 rejected) with a boundary test.

## Summary by Sourcery

Align altitude ceiling handling between backend and frontend by centralizing the maximum altitude constant and enforcing it in validation.

Bug Fixes:
- Ensure backend altitude validation rejects values above 999 to match the documented and frontend-enforced range.

Tests:
- Add boundary tests to verify 1000 ft is rejected and 999 ft is accepted for altitude commands.