### PR TITLE
fix(frontend): render N/A for null battery voltage

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -534,7 +534,7 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
           <tr>
             <td>{data.status.battery_percent}</td>
             <td>{data.status.battery_used}</td>
-            <td>{data.status.battery_voltage}</td>
+            <td>{data.status.battery_voltage ?? 'N/A'}</td>
           </tr>
         </tbody>
       </table>

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -9,7 +9,7 @@ export interface AssetStatusData {
   timestamp: string
   battery_percent: number
   battery_used: number
-  battery_voltage: number
+  battery_voltage: number | null
 }
 
 export interface AssetSearchData {

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -83,6 +83,17 @@ class StatusAPITest(TestCase):
         self.assertEqual(cmd_data['command'], 'Adjust Altitude')
         self.assertEqual(cmd_data['alt'], 0)
 
+    def test_all_status_data_with_null_battery_voltage(self):
+        """A null bat_volt passes through as null rather than an ambiguous value."""
+        self.client.login(username='testuser', password='password')
+        AssetStatus.objects.create(asset=self.asset, bat_percent=85, bat_used_mah=500, bat_volt=None)
+
+        url = reverse('all_status_data')
+        response = self.client.get(url)
+        data = response.json()
+
+        self.assertIsNone(data['assets'][0]['status']['battery_voltage'])
+
     def test_current_user_unauthenticated(self):
         """Test current_user when not logged in."""
         url = reverse('current_user')


### PR DESCRIPTION
## Description

AssetStatus.bat_volt is nullable, but battery_voltage reached the frontend typed as a plain number and rendered whatever a null value coerces to, rather than a deliberate "no data" state. Type it number | null in server.ts and render `?? 'N/A'`, matching the existing altitude pattern. Add a backend regression test asserting a null bat_volt passes through as null.

## Summary by Sourcery

Handle nullable battery voltage status end-to-end and ensure it renders as a no-data state in the UI.

Bug Fixes:
- Preserve null battery voltage values in the all_status_data API response instead of allowing ambiguous coercion.
- Render a user-friendly N/A placeholder when battery voltage is null in the frontend status table.

Tests:
- Add a regression test confirming that a null bat_volt is returned as null in the all_status_data response.