### PR TITLE
fix(frontend): show GOTO coordinates at exactly 0,0

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -566,7 +566,7 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
   if (data?.command) {
     let text = data.command.command
     if (data.command.command_code === 'GOTO') {
-      if (data.command.lat && data.command.lng) {
+      if (data.command.lat != null && data.command.lng != null) {
         text += ` ${degreesToDM(data.command.lat, 'lat')}, ${degreesToDM(data.command.lng, 'lon')}`
       }
     }


### PR DESCRIPTION
## Description

The GOTO command display gated coordinate rendering on truthiness, so a real GOTO to the equator/prime meridian (lat or lng exactly 0) was silently dropped from the operator-facing command text even though the backend stores and returns it correctly. Test presence with != null instead.

## Summary by Sourcery

Bug Fixes:
- Fix GOTO command display so coordinates with latitude or longitude equal to 0 are shown instead of being omitted.