### PR TITLE
fix(setup): stop leaking DB credentials from setup-db.sh

### DIFF
--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,9 +1,10 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
+# -x tracing is deliberately not enabled here: it would echo the sed
+# invocations below, including $DB_PASS, to stdout/logs.
 [ ! -z "$DB_HOST" ] && sed -i "s|'HOST': .*|'HOST': '$DB_HOST',|" fss/local_settings.py || true
 [ ! -z "$DB_USER" ] && sed -i "s|'USER': .*|'USER': '$DB_USER',|" fss/local_settings.py || true
 [ ! -z "$DB_NAME" ] && sed -i "s|'NAME': .*|'NAME': '$DB_NAME',|" fss/local_settings.py || true
 [ ! -z "$DB_PASS" ] && sed -i "s|'PASSWORD': .*|'PASSWORD': '$DB_PASS',|" fss/local_settings.py || true
 
-cat fss/local_settings.py
-
+echo "fss/local_settings.py database settings updated from environment variables."


### PR DESCRIPTION
## Description

The script traced with -x (echoing the sed invocations, including $DB_PASS, to stdout) and then unconditionally cat'd the rendered local_settings.py, putting the database password in terminal scrollback, CI logs, or installer output. Drop -x for this script and print a redacted summary instead of the raw file.

## Summary by Sourcery

Bug Fixes:
- Avoid leaking DB password and other connection details to stdout, logs, and installer output during database setup.