### PR TITLE
chore: fix package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "flight-safety-system-web",
   "version": "1.0.0",
-  "main": "frontend/main.js",
   "scripts": {
     "check": "tsc --noEmit && eslint frontend/ && prettier -c frontend/",
     "build-only": "esbuild $(esbuild-config)",
@@ -13,13 +12,11 @@
     "url": "ssh://git@git.home.sparlane.kiwi/flight-safety-system-web.git"
   },
   "author": "",
-  "license": "ISC",
-  "description": "",
+  "license": "GPL-2.0-only",
+  "description": "Web frontend for Flight Safety System, showing asset status and dispatching safety-critical commands.",
   "dependencies": {
     "@canterbury-air-patrol/deg-converter": "^0.3.0",
     "bootstrap": "^5.3.8",
-    "esbuild": "^0.28.1",
-    "esbuild-config": "^1.0.1",
     "leaflet": "^1.9.4",
     "react": "^19.2.7",
     "react-bootstrap": "^2.10.10",
@@ -32,6 +29,8 @@
     "@types/leaflet": "^1.9.21",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.28.1",
+    "esbuild-config": "^1.0.1",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.7.0",


### PR DESCRIPTION
## Description

License was declared ISC but the project is GPL-2.0-only. main pointed at a nonexistent frontend/main.js for an app that isn't consumed as a library. Also fill in description and move esbuild/esbuild-config out of dependencies into devDependencies, where the rest of the build toolchain lives.