### PR TITLE
chore: remove dead #dialog-modal markup from main.html

### DIFF
--- a/main/templates/main/main.html
+++ b/main/templates/main/main.html
@@ -9,16 +9,5 @@
     </head>
     <body>
         <div id="root"></div>
-        <div id="dialog-modal" class="modal fade" role="dialog">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header" id="dialog-header"></div>
-                    <div class="modal-body" id="dialog-body"></div>
-                    <div class="modal-footer">
-                        <div class="btn-group" id="dialog-buttons"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </body>
 </html>


### PR DESCRIPTION
## Description

All dialogs are rendered by react-bootstrap's Modal into #root; this hand-rolled Bootstrap modal skeleton was leftover pre-React markup with no references anywhere in the frontend.

## Summary by Sourcery

Enhancements:
- Simplify the main HTML template by deleting an unreferenced #dialog-modal container that is no longer used by the React-based modal system.