### PR TITLE
fix(frontend): stop one hung peer from freezing all polling

### DIFF
--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -43,6 +43,14 @@ const rttTimeOld = 60 * 1000
 // as a problem rather than transient latency.
 const commandAckTimeout = 15 * 1000
 
+// Poll cadence, and how long a single server's fetch may take before it is
+// treated as unreachable. The fetch timeout must stay comfortably below the
+// poll interval so one hung/blackholed peer resolves to "unreachable" well
+// before the next cycle starts, instead of stalling every server's data
+// behind it.
+const pollIntervalMs = 3 * 1000
+const pollFetchTimeoutMs = 2.5 * 1000
+
 L.Icon.Default.prototype.options.iconUrl = markerIcon
 L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
 L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
@@ -710,6 +718,7 @@ export const FSSMainPage: React.FC = () => {
   knownAssetsRef.current = knownAssets
 
   const pollAbortRef = useRef<AbortController | null>(null)
+  const unmountedRef = useRef(false)
 
   const updateData = useCallback(async () => {
     pollAbortRef.current?.abort()
@@ -722,8 +731,11 @@ export const FSSMainPage: React.FC = () => {
     const results = await Promise.all(
       serverNames.map(async (serverName) => {
         const server = snapshotServers[serverName]
+        // Bound each server's fetch independently so one hung/blackholed peer
+        // can't stall the other servers' otherwise-successful data behind it.
+        const signal = AbortSignal.any([ac.signal, AbortSignal.timeout(pollFetchTimeoutMs)])
         try {
-          const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include', signal: ac.signal })
+          const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include', signal })
           if (response.status === 403) return { serverName, data: null, unauthenticated: true }
           if (!response.ok) throw new Error(`HTTP ${response.status}`)
           const data = await response.json()
@@ -734,7 +746,11 @@ export const FSSMainPage: React.FC = () => {
       })
     )
 
-    if (ac.signal.aborted) return
+    // A superseded cycle (aborted by a newer one starting) may still have
+    // resolved good data for some servers before being superseded; apply it
+    // rather than discarding it wholesale. Only bail if the component itself
+    // unmounted meanwhile.
+    if (unmountedRef.current) return
 
     let currentServers = { ...knownServersRef.current }
     let currentAssets = { ...knownAssetsRef.current }
@@ -757,9 +773,11 @@ export const FSSMainPage: React.FC = () => {
   }, [])
 
   useEffect(() => {
+    unmountedRef.current = false
     updateData()
-    const timer = setInterval(() => updateData(), 3000)
+    const timer = setInterval(() => updateData(), pollIntervalMs)
     return () => {
+      unmountedRef.current = true
       clearInterval(timer)
       pollAbortRef.current?.abort()
     }


### PR DESCRIPTION
## Description

updateData polled every server with a single AbortController and no per-fetch timeout, then discarded the entire cycle's results (including already-successful ones) if that controller had been aborted by the time Promise.all settled. A permanently hung/blackholed peer meant every cycle got superseded by the next before completing, so no server's data was ever merged - including on first load.

Bound each server's fetch independently (pollFetchTimeoutMs, well under the pollIntervalMs cadence) so a hung peer resolves to "unreachable" on its own, and stop discarding a superseded cycle's results wholesale - only bail if the component itself unmounted.

## Summary by Sourcery

Prevent a hung frontend polling peer from blocking data updates for other servers by tightening polling intervals and handling per-server timeouts independently.

Bug Fixes:
- Ensure each server poll has its own timeout so an unresponsive server is marked unreachable without blocking other servers' data merges.
- Stop discarding results from a superseded polling cycle and only skip applying data when the main page component has unmounted.
- Use a shared polling interval constant to keep fetch timeouts safely below the poll cadence.