### PR TITLE
fix(security): union CORS peers into CSRF_TRUSTED_ORIGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ in every other peer's list.
 
 A server not listed in its peers' `CORS_ALLOWED_ORIGINS` will still receive
 and store data from aircraft, but the UI loaded from a peer will not be able
-to send authenticated commands to it.
+to poll or send authenticated commands to it.
+
+Every origin listed in `CORS_ALLOWED_ORIGINS` is automatically trusted for
+CSRF as well (`CSRF_TRUSTED_ORIGINS` is extended with it at startup), so a
+peer only needs to be listed once, here. This is what makes cross-server
+command dispatch — not just polling — work between peers.
 
 ---
 

--- a/fss/settings.py
+++ b/fss/settings.py
@@ -35,6 +35,26 @@ globals().setdefault('SESSION_COOKIE_SAMESITE', 'Lax')
 globals().setdefault('CSRF_COOKIE_SAMESITE', 'Lax')
 
 
+def merge_csrf_trusted_origins(csrf_trusted, cors_allowed):
+    """
+    Every peer trusted for cross-origin CORS reads must also be CSRF-trusted
+    for cross-origin command POSTs - in this multi-server design they are
+    exactly the same peer set. A peer listed in CORS_ALLOWED_ORIGINS but not
+    CSRF_TRUSTED_ORIGINS (as the README's multi-server example previously
+    showed) lets cross-server polling work while silently 403ing cross-server
+    commands.
+    """
+    return sorted(set(csrf_trusted) | set(cors_allowed))
+
+
+# Union CORS peers into CSRF_TRUSTED_ORIGINS here, at the framework level, so
+# the gap above can't recur regardless of which local_settings an install uses.
+CSRF_TRUSTED_ORIGINS = merge_csrf_trusted_origins(
+    globals().get('CSRF_TRUSTED_ORIGINS', []),
+    globals().get('CORS_ALLOWED_ORIGINS', [])
+)
+
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 

--- a/main/tests/test_security_settings.py
+++ b/main/tests/test_security_settings.py
@@ -3,7 +3,9 @@ Tests for security-relevant Django settings.
 """
 
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import Client, SimpleTestCase, TestCase, override_settings
+
+from fss.settings import merge_csrf_trusted_origins
 
 
 class SecuritySettingsTest(SimpleTestCase):
@@ -19,3 +21,55 @@ class SecuritySettingsTest(SimpleTestCase):
         self.assertTrue(settings.CSRF_COOKIE_SECURE)
         self.assertEqual(settings.SESSION_COOKIE_SAMESITE, 'Lax')
         self.assertEqual(settings.CSRF_COOKIE_SAMESITE, 'Lax')
+
+
+class MergeCsrfTrustedOriginsTest(SimpleTestCase):
+    """
+    A peer trusted for CORS must also become CSRF-trusted (SECURITY-05):
+    listing it in only one of the two silently breaks cross-server commands.
+    """
+
+    def test_cors_peer_is_added_to_csrf_trusted(self):
+        """A CORS-only peer is added to the CSRF-trusted set."""
+        merged = merge_csrf_trusted_origins(['https://fss1.example.com'], ['https://fss2.example.com'])
+        self.assertEqual(merged, ['https://fss1.example.com', 'https://fss2.example.com'])
+
+    def test_no_duplicates_when_already_listed_in_both(self):
+        """A peer listed in both sets is not duplicated."""
+        merged = merge_csrf_trusted_origins(['https://fss1.example.com'], ['https://fss1.example.com'])
+        self.assertEqual(merged, ['https://fss1.example.com'])
+
+    def test_empty_cors_leaves_csrf_trusted_unchanged(self):
+        """A single-server deployment with no CORS peers is unaffected."""
+        merged = merge_csrf_trusted_origins(['https://fss1.example.com'], [])
+        self.assertEqual(merged, ['https://fss1.example.com'])
+
+
+@override_settings(CSRF_TRUSTED_ORIGINS=['https://fss-peer.example.com'], ALLOWED_HOSTS=['testserver'])
+class CrossOriginCommandCsrfTest(TestCase):
+    """
+    Regression for SECURITY-05: Django's CSRF middleware rejects a cross-origin
+    POST outright (before even checking the token) unless the Origin header is
+    the request's own origin or is listed in CSRF_TRUSTED_ORIGINS. A POST from
+    a trusted peer origin with a valid token must pass that check; the same
+    request from an untrusted origin must not, regardless of the token.
+    """
+
+    def _post_with_valid_token(self, client, origin):
+        get_response = client.get('/login/')
+        csrftoken = get_response.cookies['csrftoken'].value
+        return client.post('/login/', {'csrfmiddlewaretoken': csrftoken}, HTTP_ORIGIN=origin)
+
+    def test_trusted_peer_origin_passes_csrf_check(self):
+        """A POST with Origin: a CSRF_TRUSTED_ORIGINS entry is not CSRF-rejected."""
+        client = Client(enforce_csrf_checks=True)
+        response = self._post_with_valid_token(client, 'https://fss-peer.example.com')
+        # Invalid/missing credentials still redirect to the error page; the
+        # point is that CSRF itself did not 403 the request.
+        self.assertNotEqual(response.status_code, 403)
+
+    def test_untrusted_origin_is_csrf_rejected(self):
+        """A POST with an untrusted Origin is CSRF-rejected regardless of token."""
+        client = Client(enforce_csrf_checks=True)
+        response = self._post_with_valid_token(client, 'https://not-a-peer.example.com')
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
## Description

The documented multi-server config listed peers only in CORS_ALLOWED_ORIGINS, which is enough for cross-server polling (a safe method, not CSRF-checked) but not for cross-server commanding: Django rejects a command POST whose Origin isn't the request's own origin or in that instance's CSRF_TRUSTED_ORIGINS, so a correctly-CORS-configured peer's commands still silently 403'd.

Fix it at the framework level in fss/settings.py rather than only in docs, so it can't be forgotten by any install's local_settings: every origin in CORS_ALLOWED_ORIGINS is unioned into CSRF_TRUSTED_ORIGINS via a small testable helper. Add regression tests for the union arithmetic and for the actual CSRF accept/reject behaviour via Client(enforce_csrf_checks=True), and document the new behaviour in the README's multi-server section.

## Summary by Sourcery

Ensure CORS peer origins are automatically trusted for CSRF to allow cross-server commands as well as polling.

Bug Fixes:
- Prevent cross-server POST commands from being silently rejected by CSRF when peers are only configured in CORS_ALLOWED_ORIGINS.

Enhancements:
- Introduce a helper to merge CORS_ALLOWED_ORIGINS into CSRF_TRUSTED_ORIGINS at framework startup to enforce consistent peer trust configuration.

Documentation:
- Update multi-server README documentation to explain that CORS peers are automatically added to CSRF_TRUSTED_ORIGINS and clarify cross-server polling vs command behaviour.

Tests:
- Add unit tests for the CSRF/CORS origin merge helper and regression tests verifying CSRF acceptance and rejection for trusted and untrusted cross-origin POSTs.