### PR TITLE
docs: note CORS_ALLOWED_ORIGINS peers are auto-trusted for CSRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ ALLOWED_HOSTS=localhost
 CSRF_TRUSTED_ORIGINS=
 
 # Comma-separated peer FSS server origins for multi-server deployments.
+# Each of these is automatically also trusted for CSRF, so peers only need to
+# be listed here, not duplicated in CSRF_TRUSTED_ORIGINS above.
 CORS_ALLOWED_ORIGINS=
 
 # HSTS: set to seconds to enable (e.g. 31536000 for 1 year in production).


### PR DESCRIPTION
## Description

Follow-up to the SECURITY-05 fix: clarify in .env.example that peers no longer need to be duplicated into CSRF_TRUSTED_ORIGINS.

## Summary by Sourcery

Documentation:
- Update .env.example to note that CORS_ALLOWED_ORIGINS peers are automatically trusted for CSRF and no longer need duplication in CSRF_TRUSTED_ORIGINS.