### PR TITLE
fix(deploy): run uWSGI, not the dev server, from the systemd unit

### DIFF
--- a/fss-web.service
+++ b/fss-web.service
@@ -4,9 +4,23 @@ Requires=postgresql.service
 After=postgresql.service
 
 [Service]
+# User=cap and the /home/cap/... paths below are example-specific to this
+# deployment; adjust the user and paths for your own install location.
 User=cap
 WorkingDirectory=/home/cap/software/flight-safety-system-web
-ExecStart=/home/cap/software/flight-safety-system-web/start.sh
+# start-wsgi.sh runs the production uWSGI entrypoint. start.sh (Django's
+# runserver) is documented as unsuitable for production and must not be used
+# here - see start-wsgi.sh for why.
+ExecStart=/home/cap/software/flight-safety-system-web/start-wsgi.sh
+Restart=on-failure
+RestartSec=5
+
+# Basic hardening for a service that holds aircraft-command authority.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/cap/software/flight-safety-system-web
 
 [Install]
 WantedBy=multi-user.target

--- a/start-wsgi.sh
+++ b/start-wsgi.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+set -e
 
 source venv/bin/activate
 
 ./manage.py migrate
 ./manage.py collectstatic --no-input
-uwsgi --socket 127.0.0.1:8090 --protocol=http -w fss.wsgi
+# --master supervises worker processes and restarts a crashed one; --die-on-term
+# makes uWSGI actually exit on SIGTERM (its default remaps that to a graceful
+# reload) so systemd's stop/restart actually stops it instead of reloading it.
+exec uwsgi --socket 127.0.0.1:8090 --protocol=http -w fss.wsgi --master --processes 4 --die-on-term


### PR DESCRIPTION
## Description

fss-web.service pointed ExecStart at start.sh, which runs manage.py runserver - Django's single-threaded, not-for-production dev server - contradicting the README's own "Production: start-wsgi.sh" guidance. Point it at start-wsgi.sh instead.

Also add Restart=on-failure, basic sandboxing (NoNewPrivileges, ProtectSystem=strict, ProtectHome), and give uWSGI --master/--processes supervision plus --die-on-term so systemd's stop/restart actually terminates it instead of triggering a graceful reload.

## Summary by Sourcery

Run the production uWSGI-based startup script from the systemd service and harden its behavior under systemd supervision.

Enhancements:
- Adjust the uWSGI startup script to use master/process management and proper SIGTERM handling for cleaner systemd stop/restart behavior.

Deployment:
- Update fss-web.service to start the app via start-wsgi.sh instead of the Django development server, and add restart and sandboxing options to the unit.