### PR TITLE
perf(assets): bound the RTT window-scan query to a recent time window

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
-from assets.views import RTT_SAMPLE_LIMIT, bulk_asset_status_data
+from assets.views import RTT_SAMPLE_LIMIT, RTT_SCAN_WINDOW, bulk_asset_status_data
 
 
 class AssetAPITest(TestCase):
@@ -313,6 +313,19 @@ class AssetAPITest(TestCase):
         rtt_data = data['rtt']
         self.assertEqual(rtt_data['rtt_max'], total_samples)
         self.assertEqual(rtt_data['rtt_min'], total_samples - RTT_SAMPLE_LIMIT + 1)
+
+    def test_bulk_asset_status_data_ignores_rtts_older_than_scan_window(self):
+        """RTTs older than RTT_SCAN_WINDOW are excluded from the aggregation (PERF-02)."""
+        now = timezone.now()
+        AssetRTT.objects.create(asset=self.asset, rtt=999, timestamp=now - RTT_SCAN_WINDOW - timedelta(minutes=1))
+        AssetRTT.objects.create(asset=self.asset, rtt=42, timestamp=now)
+
+        results = {r['asset']['name']: r for r in bulk_asset_status_data(Asset.objects.filter(pk=self.asset.pk))}
+
+        rtt_data = results['Test Drone']['rtt']
+        self.assertEqual(rtt_data['rtt'], 42)
+        self.assertEqual(rtt_data['rtt_min'], 42)
+        self.assertEqual(rtt_data['rtt_max'], 42)
 
     def test_asset_add_get_rejected(self):
         """Test that authenticated GET request to asset_add is rejected."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -3,6 +3,7 @@ Views for Assets
 """
 
 import contextlib
+from datetime import timedelta
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
@@ -18,6 +19,12 @@ from fss.decorators import login_required_api
 from .models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
 
 RTT_SAMPLE_LIMIT = 15
+
+# How far back the RTT window-function query below looks. Bounds the scan to
+# a fixed recent window instead of the fleet's entire history, while staying
+# a comfortable multiple of the reporting period so RTT_SAMPLE_LIMIT samples
+# are always found within it.
+RTT_SCAN_WINDOW = timedelta(hours=1)
 
 
 def server_now_ms():
@@ -274,16 +281,22 @@ def bulk_asset_status_data(assets):
 
     # Fetch the latest RTT_SAMPLE_LIMIT RTTs per asset in one query using a
     # window function — Django ORM can't express LIMIT-per-group without raw SQL.
+    # Bound by RTT_SCAN_WINDOW so the partition doesn't materialize over the
+    # fleet's entire RTT history on every poll; the cutoff is computed in
+    # Python (rather than a database-specific interval literal) so the query
+    # stays portable across the spatialite (tests) and PostGIS (production)
+    # backends.
     rtts_by_asset = {}
     asset_ids = [a.pk for a in annotated_assets]
     if asset_ids:
         placeholders = ','.join(['%s'] * len(asset_ids))
         table_name = AssetRTT._meta.db_table
+        scan_cutoff = timezone.now() - RTT_SCAN_WINDOW
         for rtt in AssetRTT.objects.raw(
             "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY asset_id ORDER BY timestamp DESC) AS rn "
-            f"FROM {table_name} WHERE asset_id IN ({placeholders})) t WHERE rn <= %s "
+            f"FROM {table_name} WHERE asset_id IN ({placeholders}) AND timestamp > %s) t WHERE rn <= %s "
             "ORDER BY asset_id, rn",
-            [*asset_ids, RTT_SAMPLE_LIMIT]
+            [*asset_ids, scan_cutoff, RTT_SAMPLE_LIMIT]
         ):
             rtts_by_asset.setdefault(rtt.asset_id, []).append(rtt)
 


### PR DESCRIPTION
## Description

bulk_asset_status_data's per-asset RTT query used a ROW_NUMBER() window function with no timestamp bound, so Postgres materialized the partition over the fleet's entire RTT history before filtering to the newest RTT_SAMPLE_LIMIT rows - on every /current/all.json/ poll, i.e. every 3s per open tab. Add RTT_SCAN_WINDOW (1h) as a WHERE bound, computed in Python rather than a DB-specific interval literal so the query stays portable across spatialite (tests) and PostGIS.

Retention policy for the underlying tables (PERF-02's other half) is a separate, deployment-specific decision left open.

## Summary by Sourcery

Bound per-asset RTT aggregation to a recent time window to reduce query workload while keeping backend portability.

Bug Fixes:
- Exclude RTT records older than a configured scan window from bulk asset status aggregation.

Enhancements:
- Introduce a configurable RTT scan window constant and use it to constrain the raw SQL window-function query for bulk asset status.

Tests:
- Add tests verifying that RTT samples older than the scan window are ignored and that aggregation reflects only recent RTTs.