### PR TITLE
fix(frontend): prune assets/servers a poll no longer reports

### DIFF
--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -143,4 +143,45 @@ describe('mergeServerAssets', () => {
 
     expect(result.Drone.servers.alpha.serverNow).toBe(1700000000000)
   })
+
+  it('drops a server entry once that server no longer reports the asset', () => {
+    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'alpha', [])
+
+    expect(result.Drone).toBeUndefined()
+  })
+
+  it('prunes only the reporting server, keeping other servers intact', () => {
+    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
+    const both = mergeServerAssets(first, 'beta', [statusFor('Drone', 9)])
+    const result = mergeServerAssets(both, 'alpha', [])
+
+    expect(Object.keys(result.Drone.servers)).toEqual(['beta'])
+  })
+
+  it('falls back to a remaining server when the pruned one was selected', () => {
+    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
+    const both = mergeServerAssets(first, 'beta', [statusFor('Drone', 9)])
+    const result = mergeServerAssets(both, 'alpha', [])
+
+    expect(result.Drone.selectedServerName).toBe('beta')
+  })
+
+  it('does not prune a server that simply was not polled this cycle', () => {
+    // A failed/unreachable/unauthenticated poll never calls mergeServerAssets
+    // for that server at all - only a *different* server's successful poll
+    // runs here, and it must not touch entries it has no data about.
+    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'beta', [])
+
+    expect(result.Drone.servers.alpha.assetPk).toBe(5)
+  })
+
+  it('leaves an asset untouched when the same server reports it again', () => {
+    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'alpha', [statusFor('Drone', 5)])
+
+    expect(Object.keys(result)).toEqual(['Drone'])
+    expect(result.Drone.servers.alpha.assetPk).toBe(5)
+  })
 })

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -79,8 +79,34 @@ export const assetPositionMostRecent = (asset: AssetState): AssetPositionData | 
   return best
 }
 
-export const mergeServerAssets = (currentAssets: Record<string, AssetState>, serverName: string, assets: AssetStatus[], serverNow?: number): Record<string, AssetState> => {
+// Reconcile this server's reported assets against what it reported last poll,
+// dropping its entry from any asset it no longer reports and pruning the
+// asset entirely once that was its last server. Only call this for a
+// server's *successful* poll — a failed/unreachable/unauthenticated poll
+// should leave last-known data + age styling in place instead.
+const pruneStaleServerEntries = (currentAssets: Record<string, AssetState>, serverName: string, reportedNames: Set<string>): Record<string, AssetState> => {
   const nextAssets = { ...currentAssets }
+  for (const [assetName, assetState] of Object.entries(nextAssets)) {
+    if (reportedNames.has(assetName) || !(serverName in assetState.servers)) continue
+    const remainingServers = { ...assetState.servers }
+    delete remainingServers[serverName]
+    const remainingServerNames = Object.keys(remainingServers)
+    if (remainingServerNames.length === 0) {
+      delete nextAssets[assetName]
+    } else {
+      nextAssets[assetName] = {
+        ...assetState,
+        servers: remainingServers,
+        selectedServerName: assetState.selectedServerName === serverName ? remainingServerNames[0] : assetState.selectedServerName
+      }
+    }
+  }
+  return nextAssets
+}
+
+export const mergeServerAssets = (currentAssets: Record<string, AssetState>, serverName: string, assets: AssetStatus[], serverNow?: number): Record<string, AssetState> => {
+  const reportedNames = new Set(assets.map((assetData) => assetData.asset.name))
+  const nextAssets = pruneStaleServerEntries(currentAssets, serverName, reportedNames)
   for (const assetData of assets) {
     const assetName = assetData.asset.name
     const existing = nextAssets[assetName] ?? createAsset(assetName)


### PR DESCRIPTION
## Description

mergeServerAssets only ever added or overwrote entries, so an asset renamed, deleted, or reassigned away from a server kept its stale per-server entry (and the whole ghost asset card) forever once last-known data stopped updating - fading only via CSS age classes, never disappearing.

Reconcile against each *successful* poll instead: drop a server's entry from any asset it no longer reports, prune the asset entirely once that was its last server, and fall back to another remaining server if the pruned one was selected. A failed/unreachable poll never calls mergeServerAssets for that server at all, so last-known data + age styling is untouched, as intended.

## Summary by Sourcery

Prune stale per-server asset entries on each successful poll so assets no longer reported by a server are removed or reassigned to remaining servers.

Bug Fixes:
- Ensure assets and their server entries disappear when a server stops reporting them, preventing ghost asset cards from persisting.
- Avoid removing server asset data when a server was simply not polled or failed, preserving last-known state and age styling.

Tests:
- Add unit tests covering pruning of non-reporting servers, fallback selection to remaining servers, preservation of data for unpolled servers, and idempotent updates when servers re-report the same assets.