### PR TITLE
ci(chore-03): run manage.py check --deploy against production settings

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -42,6 +42,18 @@ jobs:
           source venv/bin/activate
           pip install -r requirements.txt
 
+      # STATICFILES_DIRS points at dist/, the frontend build output; a real
+      # deploy always builds it first (setup.sh, docker/start.sh), and
+      # manage.py check --deploy validates STATICFILES_DIRS regardless of
+      # whether collectstatic actually runs. Build it here too so the check
+      # sees the same production-like layout, not staticfiles.W004 noise from
+      # a directory that only doesn't exist because this job skipped the
+      # frontend build.
+      - name: Build frontend
+        run: |
+          npm ci
+          npm run build
+
       # Runs manage.py check --deploy against docker/local_settings.py - the
       # actual production settings module - rather than test_settings.py
       # (which intentionally relaxes things) or a dev local_settings.py with

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -22,3 +22,37 @@ jobs:
       - name: check-code
         run: |
           ./check-code.sh
+
+  deploy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt depends
+        run: |
+          sudo apt update
+          sudo apt install -y gdal-bin libgdal-dev
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+      - name: Install dependencies
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      # Runs manage.py check --deploy against docker/local_settings.py - the
+      # actual production settings module - rather than test_settings.py
+      # (which intentionally relaxes things) or a dev local_settings.py with
+      # DEBUG=True. Dummy DB_* values are enough: check --deploy validates
+      # settings, it never connects to the database.
+      - name: Check production-like settings
+        run: |
+          source venv/bin/activate
+          cp docker/local_settings.py fss/local_settings.py
+          export DJANGO_SECRET_KEY="$(python3 -c 'import secrets; print(secrets.token_urlsafe(50))')"
+          export DB_HOST=dummy DB_NAME=dummy DB_USER=dummy DB_PASS=dummy
+          export ALLOWED_HOSTS=fss.example.com
+          export CSRF_TRUSTED_ORIGINS=https://fss.example.com
+          ./manage.py check --deploy --fail-level WARNING

--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -49,6 +49,17 @@ if _hsts_seconds:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = os.environ.get('SECURE_HSTS_INCLUDE_SUBDOMAINS', 'true').lower() == 'true'
     SECURE_HSTS_PRELOAD = os.environ.get('SECURE_HSTS_PRELOAD', 'false').lower() == 'true'
 
+# security.W004 (HSTS) and security.W008 (SECURE_SSL_REDIRECT) are silenced
+# deliberately, not fixed: this deployment model puts a TLS-terminating
+# reverse proxy in front of uWSGI, and that proxy - not Django - is
+# responsible for enforcing HTTPS and issuing the HTTP->HTTPS redirect.
+# Django only sees plain HTTP from the proxy unless SECURE_HSTS_SECONDS is
+# opted into above (which also wires up SECURE_PROXY_SSL_HEADER). Silencing
+# just these two checks (rather than skipping `manage.py check --deploy`
+# altogether) keeps it meaningful for everything else it catches - DEBUG,
+# secret key strength, cookie flags, etc.
+SILENCED_SYSTEM_CHECKS = ['security.W004', 'security.W008']
+
 # Peer FSS server origins for cross-origin credentialed fetches.
 # Each server must appear in the other servers' lists.
 CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
## Description

Nothing in CI verified the deployment settings that the project's whole security posture depends on (secure cookies, DEBUG=False, HSTS, etc.) - a misconfigured production instance was only caught in the field. Add a job that copies docker/local_settings.py (the real production settings module, not test_settings.py or a dev local_settings.py) into place and runs the deploy check against it with representative env vars.

Silence security.W004 (HSTS) and security.W008 (SECURE_SSL_REDIRECT) deliberately in docker/local_settings.py: this deployment model puts a TLS-terminating reverse proxy in front of uWSGI, and that proxy - not Django - enforces HTTPS and the redirect. Everything else the check catches (DEBUG, secret key strength, cookie flags) still fails the job.

## Summary by Sourcery

Add CI coverage to run Django's deploy checks against production-like settings and align production config with the reverse-proxy TLS deployment model.

New Features:
- Introduce a deploy-check GitHub Actions job that runs manage.py check --deploy against the production settings module using representative environment variables.

Enhancements:
- Configure docker/local_settings.py to silence specific HTTPS-related system checks that are handled by the front-end TLS-terminating reverse proxy while keeping other deploy checks enforced.