### PR TITLE
ci(chore-05): run the Django test suite against PostGIS

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -68,3 +68,52 @@ jobs:
           export ALLOWED_HOSTS=fss.example.com
           export CSRF_TRUSTED_ORIGINS=https://fss.example.com
           ./manage.py check --deploy --fail-level WARNING
+
+  postgis-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fss_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install apt depends
+        run: |
+          sudo apt update
+          sudo apt install -y gdal-bin libgdal-dev
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+      - name: Install dependencies
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      # Exercises the same suite against the production engine (PostGIS)
+      # instead of the SpatiaLite default in test_settings.py - migrations run
+      # as part of the test database setup, so engine-specific migration SQL
+      # is covered too, not just query behaviour.
+      - name: Run Django tests against PostGIS
+        env:
+          DJANGO_SECRET_KEY: dummy-secret-key-for-ci-only
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_NAME: fss_test
+          DB_USER: postgres
+          DB_PASS: postgres
+        run: |
+          source venv/bin/activate
+          ./manage.py test --settings=fss.test_settings_postgis

--- a/fss/test_settings_postgis.py
+++ b/fss/test_settings_postgis.py
@@ -1,0 +1,23 @@
+"""
+Django settings for testing against PostGIS - the engine production (and the
+FSS server sharing the same database) actually uses, unlike the SpatiaLite
+default in test_settings.py. Connection details come from the environment so
+CI can point this at a postgis service container; see
+.github/workflows/checkcode.yml.
+"""
+
+import os
+
+# pylint: disable=W0401,W0614
+from .settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'HOST': os.environ.get('DB_HOST', 'localhost'),
+        'PORT': os.environ.get('DB_PORT', '5432'),
+        'NAME': os.environ.get('DB_NAME', 'fss_test'),
+        'USER': os.environ.get('DB_USER', 'postgres'),
+        'PASSWORD': os.environ.get('DB_PASS', 'postgres'),
+    }
+}


### PR DESCRIPTION
## Description

fss/test_settings.py runs on spatialite; production (and the FSS server sharing the same database) is PostGIS. Engine differences - geometry function behaviour, transaction/locking semantics, migration SQL - were only exercised indirectly by the Tier-3 integration suite.

Add fss/test_settings_postgis.py (connection details from the environment) and a CI job with a postgis/postgis service container running the same suite. Migrations run as part of the test database setup, so migration SQL is covered too, not just query behaviour. Verified locally against a real postgis/postgis:16-3.4 container: all 61 tests pass unchanged. Keep spatialite as the default for fast local runs.

## Summary by Sourcery

Run the Django test suite against a PostGIS-backed database in CI to validate behaviour against the production spatial engine.

New Features:
- Add PostGIS-specific Django test settings that read database connection details from environment variables.

CI:
- Add a GitHub Actions job that provisions a PostGIS service container and runs the Django test suite using the PostGIS test settings.