### PR TITLE
ci(chore-06): run checks on push and gate the Docker publish

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -1,6 +1,10 @@
 name: Run Check Code
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,14 @@ on:
 
 jobs:
 
+  checkcode:
+    uses: ./.github/workflows/checkcode.yml
+
+  eslint:
+    uses: ./.github/workflows/eslint.yml
+
   build:
+    needs: [checkcode, eslint]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,7 +1,10 @@
 name: ESLint
 
 on:
-  pull_request
+  pull_request:
+  push:
+    branches: [develop, main]
+  workflow_call:
 
 jobs:
   eslint:


### PR DESCRIPTION
## Description

checkcode.yml and eslint.yml only triggered on pull_request, but docker-image.yml pushes the built image to Docker Hub tagged :latest on every push to develop - so a direct push (this repo's normal history) bypassed lint, typecheck, and the test suite entirely and still landed in the tag deployments pull.

Add push (develop, main) triggers to both check workflows, and add workflow_call so docker-image.yml can call them as jobs and gate the build job on both with needs: - the single-workflow needs: approach recommended over workflow_run, which has its own branch/ref subtleties.

## Summary by Sourcery

Gate Docker image publishing on successful lint and code checks and ensure check workflows run on pushes to main and develop.

CI:
- Add push triggers for checkcode and ESLint workflows on main and develop branches.
- Expose checkcode and ESLint workflows via workflow_call so they can be invoked from the Docker image workflow.
- Make the Docker image build job depend on successful completion of checkcode and ESLint jobs.