### PR TITLE
test(frontend,main): staleness/degraded-rendering tests (TEST-02)

### DIFF
--- a/frontend/rendering.test.ts
+++ b/frontend/rendering.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AssetCommandData } from './server'
+import { assetPositionTimeOld, assetPositionTimeWarn, batteryTimeOld, batteryTimeWarn, commandAckAge, dataAgeClass } from './rendering'
+
+const SERVER_NOW = 1_700_000_000_000
+
+const isoAt = (offsetMs: number) => new Date(SERVER_NOW - offsetMs).toISOString()
+
+const makeCommand = (overrides: Partial<AssetCommandData> = {}): AssetCommandData => ({
+  timestamp: isoAt(0),
+  command: 'Return to Launch',
+  command_code: 'RTL',
+  ack_state: 'pending',
+  ...overrides
+})
+
+describe('dataAgeClass', () => {
+  it('is fresh when the data point is newer than the warn threshold', () => {
+    const cls = dataAgeClass(isoAt(assetPositionTimeWarn - 1), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
+    expect(cls).toBe('')
+  })
+
+  it('is warn once older than the warn threshold but not yet old', () => {
+    const cls = dataAgeClass(isoAt(assetPositionTimeWarn + 1), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
+    expect(cls).toBe('asset-position-warn')
+  })
+
+  it('is old once older than the old threshold', () => {
+    const cls = dataAgeClass(isoAt(assetPositionTimeOld + 1), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
+    expect(cls).toBe('asset-position-old')
+  })
+
+  it('computes each indicator independently: stale battery does not affect a fresh position', () => {
+    const positionClass = dataAgeClass(isoAt(0), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
+    const batteryClass = dataAgeClass(isoAt(batteryTimeOld + 1), batteryTimeOld, batteryTimeWarn, 'asset-battery-time', SERVER_NOW)
+
+    expect(positionClass).toBe('')
+    expect(batteryClass).toBe('asset-battery-time-old')
+  })
+
+  it('ages against serverNow, unaffected by a skewed browser clock', () => {
+    const realNow = Date.now
+    try {
+      // Browser clock is 5 minutes ahead of the server; a fresh data point
+      // would misreport as stale if the age were computed against it.
+      Date.now = () => SERVER_NOW + 5 * 60 * 1000
+      const cls = dataAgeClass(isoAt(0), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
+      expect(cls).toBe('')
+    } finally {
+      Date.now = realNow
+    }
+  })
+
+  it('falls back to the browser clock when serverNow is absent', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(SERVER_NOW)
+      const cls = dataAgeClass(isoAt(assetPositionTimeOld + 1), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position')
+      expect(cls).toBe('asset-position-old')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('commandAckAge', () => {
+  it('falls back to the browser clock when serverNow is absent', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(SERVER_NOW)
+      const command = makeCommand({ timestamp: isoAt(5000) })
+      expect(commandAckAge(command)).toBe(5000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -54,6 +54,26 @@ class StatusAPITest(TestCase):
         self.assertGreaterEqual(data['server_now'], before)
         self.assertLessEqual(data['server_now'], after)
 
+    def test_all_status_data_with_no_asset_data_still_has_server_now(self):
+        """
+        An asset with no position/status/search/command data yet must still
+        carry server_now, so the frontend's clock-skew-safe aging (which keys
+        entirely off this field) never silently disables itself because a
+        no-data asset happened to omit it (TEST-02).
+        """
+        self.client.login(username='testuser', password='password')
+        url = reverse('all_status_data')
+        response = self.client.get(url)
+        data = response.json()
+
+        asset_data = data['assets'][0]
+        self.assertNotIn('position', asset_data)
+        self.assertNotIn('status', asset_data)
+        self.assertNotIn('search', asset_data)
+        self.assertNotIn('command', asset_data)
+        self.assertIn('server_now', data)
+        self.assertIsInstance(data['server_now'], int)
+
     def test_all_status_data_with_details(self):
         """Test with position and status data."""
         self.client.login(username='testuser', password='password')


### PR DESCRIPTION
## Description

Pin dataAgeClass's fresh/warn/old boundaries against the exported threshold constants (not copied literals), confirm each indicator ages independently (a stale battery doesn't affect a fresh position's class), and confirm ages are computed against serverNow rather than the browser clock - including a browser clock skewed 5 minutes ahead producing no change for fresh data. Cover commandAckAge's same documented fallback.

Backend: guard that an asset with no position/status/search/command data at all still carries server_now, so the frontend's aging can't silently disable itself due to a missing top-level key.

## Summary by Sourcery

Add frontend and backend tests to verify data-age rendering uses server-provided time, handles clock skew, and always exposes server_now for assets without data.

New Features:
- Introduce vitest coverage for dataAgeClass and commandAckAge to validate age classifications and serverNow/browser clock fallback behavior.

Bug Fixes:
- Ensure assets with no position, status, search, or command data still include server_now in all_status_data responses so frontend aging logic remains active.

Tests:
- Add backend test confirming server_now is present even when an asset has no associated data.
- Add frontend unit tests covering dataAgeClass thresholds, independence of indicators, serverNow-based aging under browser clock skew, and serverNow/browser clock fallback for commandAckAge.