### PR TITLE
test: tag existing Django tests with @satisfies TC-WEB-* IDs

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
 from assets.views import RTT_SAMPLE_LIMIT, RTT_SCAN_WINDOW, bulk_asset_status_data
+from fss.satisfies import satisfies
 
 
 class AssetAPITest(TestCase):
@@ -46,6 +47,7 @@ class AssetAPITest(TestCase):
         self.assertEqual(cmd.command, 'RTL')
         self.assertEqual(cmd.issued_by, self.user)
 
+    @satisfies('TC-WEB-008')
     def test_asset_command_records_issuer(self):
         """The issuing user is recorded on the command and surfaced in the API."""
         self.client.force_login(self.user)
@@ -108,6 +110,7 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode(), 'Invalid command')
 
+    @satisfies('TC-WEB-012')
     def test_asset_command_set_invalid_altitude(self):
         """Test setting an invalid altitude."""
         self.client.force_login(self.user)
@@ -130,6 +133,7 @@ class AssetAPITest(TestCase):
         response = self.client.post(url, {'command': 'ALT', 'altitude': 'high'})
         self.assertEqual(response.status_code, 400)
 
+    @satisfies('TC-WEB-012')
     def test_asset_command_set_invalid_coordinates(self):
         """Test setting invalid coordinates for GOTO."""
         self.client.force_login(self.user)
@@ -143,6 +147,7 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode(), 'Invalid Lat/Long')
 
+    @satisfies('TC-WEB-012')
     def test_asset_command_set_out_of_range_coordinates(self):
         """Test that out-of-range lat/lng values are rejected."""
         self.client.force_login(self.user)

--- a/main/tests/test_unauth_sweep.py
+++ b/main/tests/test_unauth_sweep.py
@@ -10,6 +10,7 @@ from django.urls import NoReverseMatch, get_resolver, reverse
 from django.urls.resolvers import URLPattern, URLResolver
 
 from assets.models import Asset, AssetCommand
+from fss.satisfies import satisfies
 
 # Endpoints deliberately reachable without authentication: the SPA shell (its
 # auth-gated data is fetched separately via JS), the login flow itself, and
@@ -53,6 +54,7 @@ class UnauthenticatedAccessSweepTest(TestCase):
     unauthenticated request, unless explicitly allowlisted as public.
     """
 
+    @satisfies('TC-WEB-001')
     def test_unauthenticated_requests_are_rejected(self):
         """Sweep every named URL pattern this project owns for a 302/403."""
         checked = []

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetStatus
 from config.models import AssetConfig, ServerConfig, SMMConfig
+from fss.satisfies import satisfies
 
 
 class StatusAPITest(TestCase):
@@ -27,6 +28,7 @@ class StatusAPITest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
+    @satisfies('TC-WEB-005')
     def test_all_status_data_authenticated(self):
         """Test the all_status_data endpoint when logged in."""
         self.client.login(username='testuser', password='password')
@@ -151,6 +153,7 @@ class StatusAPITest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
+    @satisfies('TC-WEB-002')
     def test_asset_list_authenticated(self):
         """Test asset_list returns data when logged in."""
         self.client.login(username='testuser', password='password')


### PR DESCRIPTION
## Description

TC-WEB-001 (unauth sweep), TC-WEB-002 (asset list), TC-WEB-005 (status payload), TC-WEB-008 (issuer attribution), and TC-WEB-012 (GOTO/altitude validation) - the minimum set TEST-06 called out as already covered. Tag only what each test substantially verifies.

## Summary by Sourcery

Tag existing Django tests with satisfies markers for TC-WEB compliance coverage.

New Features:
- Introduce satisfies markers on existing tests to map them to specific TC-WEB requirement IDs.

Tests:
- Annotate unauthenticated sweep, asset list, status payload, issuer attribution, and GOTO/altitude validation tests with TC-WEB requirement IDs to formalize coverage mapping.