### PR TITLE
test(frontend): tag staleness tests with // satisfies TC-WEB-* comments

### DIFF
--- a/frontend/rendering.test.ts
+++ b/frontend/rendering.test.ts
@@ -51,11 +51,13 @@ describe('dataAgeClass', () => {
     expect(cls).toBe('asset-position-warn')
   })
 
+  // satisfies: TC-WEB-006
   it('is old once older than the old threshold', () => {
     const cls = dataAgeClass(isoAt(assetPositionTimeOld + 1), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
     expect(cls).toBe('asset-position-old')
   })
 
+  // satisfies: TC-WEB-020, TC-WEB-021
   it('computes each indicator independently: stale battery does not affect a fresh position', () => {
     const positionClass = dataAgeClass(isoAt(0), assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', SERVER_NOW)
     const batteryClass = dataAgeClass(isoAt(batteryTimeOld + 1), batteryTimeOld, batteryTimeWarn, 'asset-battery-time', SERVER_NOW)


### PR DESCRIPTION
## Description

TC-WEB-006 (stale position flagged) and TC-WEB-020/TC-WEB-021 (battery staleness warning; mixed freshness states shown independently per indicator), collected by manage.py satisfies_report's frontend scan.

## Summary by Sourcery

Tests:
- Annotate data age and indicator independence tests with TC-WEB-006, TC-WEB-020, and TC-WEB-021 satisfaction comments for test coverage reporting.