### PR TITLE
ci(test-06): archive the TC-WEB-* traceability report

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -27,6 +27,19 @@ jobs:
         run: |
           ./check-code.sh
 
+      # TEST-06: TC-WEB-* traceability report from @satisfies-tagged Django
+      # tests and // satisfies: comments in the frontend Vitest suite. The
+      # CAP master-plan audit merges this with the Tier-2/Tier-3 reports.
+      - name: Generate TC-WEB-* traceability report
+        run: |
+          source venv/bin/activate
+          ./manage.py satisfies_report --settings=fss.test_settings --output=satisfies-report.json
+      - name: Archive traceability report
+        uses: actions/upload-artifact@v4
+        with:
+          name: satisfies-report
+          path: satisfies-report.json
+
   deploy-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Run manage.py satisfies_report after check-code.sh in the build job and archive it as a CI artifact, so the CAP master-plan audit can pull each PR's/branch's current traceability evidence without re-deriving it locally.

## Summary by Sourcery

Add generation and archival of the TC-WEB traceability report to the CI check-code workflow.

CI:
- Run the Django satisfies_report command in the build job to produce a TC-WEB traceability JSON report.
- Archive the generated traceability report as a CI artifact for CAP master-plan audits.