### PR TITLE
Fix uwsgi ignoring SIGTERM on docker stop (BUG-07)

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -19,4 +19,5 @@ exec uwsgi \
     --master \
     --workers 4 \
     --threads 2 \
-    --static-map /static/=/code/static/
+    --static-map /static/=/code/static/ \
+    --die-on-term


### PR DESCRIPTION
## Description

Add --die-on-term so SIGTERM exits uwsgi instead of triggering a brutal reload, letting docker stop/systemctl stop/pod termination shut the container down within its grace period instead of being force-killed after it expires.

## Summary by Sourcery

Bug Fixes:
- Prevent uwsgi from performing a brutal reload and being force-killed when Docker or systemd sends SIGTERM by enabling graceful termination instead.