### PR TITLE
fix(frontend): key servers by canonical origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ First production release.
 
 ### Bug Fixes
 
+- Server state and command dispatch targets are keyed by canonical URL origin rather than operator-assigned server names, preventing the local `direct` alias from causing duplicate polls and commands.
 - Command status comparisons in the frontend now use the raw command code (`'GOTO'`, `'ALT'`, `'MAN'`) returned as `command_code` in the API response, rather than the Django display string (`'Goto Position'` etc.) which could silently break if wording changed.
 - Poll requests are now cancelled with `AbortController` before the next poll fires, preventing stale responses from overwriting state when a server is slow.
 - `window.location.origin` used for the direct server URL instead of the fragile `href.slice(0, -1)`.

--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -4,14 +4,14 @@ import { AssetState, createAsset, mergeServerAssets, sendAssetCommand } from './
 import { ServerState, createServer } from './server'
 import { AssetStatus } from './server'
 
-const makeServer = (name: string, csrfToken = 'tok'): ServerState => ({
-  ...createServer(name, '10.0.0.1', 8080, `https://${name}.example`),
+const makeServer = (name: string, csrfToken = 'tok', url = `https://${name}.example`): ServerState => ({
+  ...createServer(name, '10.0.0.1', 8080, url),
   csrfToken
 })
 
-const makeAsset = (name: string, servers: Array<{ serverName: string; assetPk: number }>): AssetState => ({
+const makeAsset = (name: string, servers: Array<{ serverKey: string; serverName?: string; assetPk: number }>): AssetState => ({
   name,
-  servers: Object.fromEntries(servers.map((s) => [s.serverName, { serverName: s.serverName, assetPk: s.assetPk }]))
+  servers: Object.fromEntries(servers.map((s) => [s.serverKey, { serverKey: s.serverKey, serverName: s.serverName ?? s.serverKey, assetPk: s.assetPk }]))
 })
 
 const statusFor = (name: string, pk: number): AssetStatus => ({ asset: { name, pk } })
@@ -26,7 +26,7 @@ describe('sendAssetCommand', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const servers = { alpha: makeServer('alpha', 'csrf-123') }
-    const asset = makeAsset('Drone', [{ serverName: 'alpha', assetPk: 42 }])
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 42 }])
 
     await sendAssetCommand(servers, asset, { command: 'RTL' })
 
@@ -45,7 +45,7 @@ describe('sendAssetCommand', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const servers = { alpha: makeServer('alpha') }
-    const asset = makeAsset('Drone', [{ serverName: 'alpha', assetPk: 7 }])
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 7 }])
 
     await sendAssetCommand(servers, asset, { command: 'GOTO', latitude: -43.5, longitude: 172.6 })
 
@@ -61,8 +61,8 @@ describe('sendAssetCommand', () => {
 
     const servers = { alpha: makeServer('alpha'), beta: makeServer('beta') }
     const asset = makeAsset('Drone', [
-      { serverName: 'alpha', assetPk: 1 },
-      { serverName: 'beta', assetPk: 2 }
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'beta', assetPk: 2 }
     ])
 
     await sendAssetCommand(servers, asset, { command: 'HOLD' })
@@ -79,8 +79,8 @@ describe('sendAssetCommand', () => {
 
     const servers = { alpha: makeServer('alpha') }
     const asset = makeAsset('Drone', [
-      { serverName: 'alpha', assetPk: 1 },
-      { serverName: 'ghost', assetPk: 2 }
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'ghost', assetPk: 2 }
     ])
 
     await sendAssetCommand(servers, asset, { command: 'RTL' })
@@ -95,8 +95,8 @@ describe('sendAssetCommand', () => {
 
     const servers = { alpha: makeServer('alpha'), beta: makeServer('beta') }
     const asset = makeAsset('Drone', [
-      { serverName: 'alpha', assetPk: 1 },
-      { serverName: 'beta', assetPk: 2 }
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'beta', assetPk: 2 }
     ])
 
     await expect(sendAssetCommand(servers, asset, { command: 'RTL' })).rejects.toThrow(/queued on 1 of 2 server\(s\).*beta: 500 Server Error/s)
@@ -107,81 +107,101 @@ describe('sendAssetCommand', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const servers = { alpha: makeServer('alpha') }
-    const asset = makeAsset('Drone', [{ serverName: 'alpha', assetPk: 1 }])
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1 }])
 
     await expect(sendAssetCommand(servers, asset, { command: 'RTL' })).rejects.toThrow(/not authenticated/)
+  })
+
+  it('dispatches only once when legacy aliases point at the same origin', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const origin = 'https://fss1.example'
+    const servers = {
+      direct: makeServer('direct', 'tok', origin),
+      fss1: makeServer('fss1', 'tok', `${origin}:443/`)
+    }
+    const asset = makeAsset('Drone', [
+      { serverKey: 'direct', assetPk: 1 },
+      { serverKey: 'fss1', assetPk: 1 }
+    ])
+
+    await sendAssetCommand(servers, asset, { command: 'RTL' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('mergeServerAssets', () => {
   it('adds a previously-unseen asset keyed by name', () => {
-    const result = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
 
     expect(Object.keys(result)).toEqual(['Drone'])
-    expect(result.Drone.servers.alpha.assetPk).toBe(5)
-    expect(result.Drone.selectedServerName).toBe('alpha')
+    expect(result.Drone.servers['alpha-origin'].assetPk).toBe(5)
+    expect(result.Drone.servers['alpha-origin'].serverName).toBe('alpha')
+    expect(result.Drone.selectedServerKey).toBe('alpha-origin')
   })
 
   it('merges a second server into an existing asset without dropping the first', () => {
-    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
-    const result = mergeServerAssets(first, 'beta', [statusFor('Drone', 9)])
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'beta-origin', 'beta', [statusFor('Drone', 9)])
 
-    expect(Object.keys(result.Drone.servers).sort()).toEqual(['alpha', 'beta'])
-    expect(result.Drone.servers.alpha.assetPk).toBe(5)
-    expect(result.Drone.servers.beta.assetPk).toBe(9)
+    expect(Object.keys(result.Drone.servers).sort()).toEqual(['alpha-origin', 'beta-origin'])
+    expect(result.Drone.servers['alpha-origin'].assetPk).toBe(5)
+    expect(result.Drone.servers['beta-origin'].assetPk).toBe(9)
   })
 
   it('keeps an already-selected server when merging more data', () => {
-    const existing = { Drone: { ...createAsset('Drone'), selectedServerName: 'beta' } }
-    const result = mergeServerAssets(existing, 'alpha', [statusFor('Drone', 5)])
+    const existing = { Drone: { ...createAsset('Drone'), selectedServerKey: 'beta-origin' } }
+    const result = mergeServerAssets(existing, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
 
-    expect(result.Drone.selectedServerName).toBe('beta')
+    expect(result.Drone.selectedServerKey).toBe('beta-origin')
   })
 
   it('records the server clock alongside the merged data', () => {
-    const result = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)], 1700000000000)
+    const result = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)], 1700000000000)
 
-    expect(result.Drone.servers.alpha.serverNow).toBe(1700000000000)
+    expect(result.Drone.servers['alpha-origin'].serverNow).toBe(1700000000000)
   })
 
   it('drops a server entry once that server no longer reports the asset', () => {
-    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
-    const result = mergeServerAssets(first, 'alpha', [])
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'alpha-origin', 'alpha', [])
 
     expect(result.Drone).toBeUndefined()
   })
 
   it('prunes only the reporting server, keeping other servers intact', () => {
-    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
-    const both = mergeServerAssets(first, 'beta', [statusFor('Drone', 9)])
-    const result = mergeServerAssets(both, 'alpha', [])
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const both = mergeServerAssets(first, 'beta-origin', 'beta', [statusFor('Drone', 9)])
+    const result = mergeServerAssets(both, 'alpha-origin', 'alpha', [])
 
-    expect(Object.keys(result.Drone.servers)).toEqual(['beta'])
+    expect(Object.keys(result.Drone.servers)).toEqual(['beta-origin'])
   })
 
   it('falls back to a remaining server when the pruned one was selected', () => {
-    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
-    const both = mergeServerAssets(first, 'beta', [statusFor('Drone', 9)])
-    const result = mergeServerAssets(both, 'alpha', [])
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const both = mergeServerAssets(first, 'beta-origin', 'beta', [statusFor('Drone', 9)])
+    const result = mergeServerAssets(both, 'alpha-origin', 'alpha', [])
 
-    expect(result.Drone.selectedServerName).toBe('beta')
+    expect(result.Drone.selectedServerKey).toBe('beta-origin')
   })
 
   it('does not prune a server that simply was not polled this cycle', () => {
     // A failed/unreachable/unauthenticated poll never calls mergeServerAssets
     // for that server at all - only a *different* server's successful poll
     // runs here, and it must not touch entries it has no data about.
-    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
-    const result = mergeServerAssets(first, 'beta', [])
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'beta-origin', 'beta', [])
 
-    expect(result.Drone.servers.alpha.assetPk).toBe(5)
+    expect(result.Drone.servers['alpha-origin'].assetPk).toBe(5)
   })
 
   it('leaves an asset untouched when the same server reports it again', () => {
-    const first = mergeServerAssets({}, 'alpha', [statusFor('Drone', 5)])
-    const result = mergeServerAssets(first, 'alpha', [statusFor('Drone', 5)])
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const result = mergeServerAssets(first, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
 
     expect(Object.keys(result)).toEqual(['Drone'])
-    expect(result.Drone.servers.alpha.assetPk).toBe(5)
+    expect(result.Drone.servers['alpha-origin'].assetPk).toBe(5)
   })
 })

--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -11,7 +11,7 @@ const makeServer = (name: string, csrfToken = 'tok', url = `https://${name}.exam
 
 const makeAsset = (name: string, servers: Array<{ serverKey: string; serverName?: string; assetPk: number }>): AssetState => ({
   name,
-  servers: Object.fromEntries(servers.map((s) => [s.serverKey, { serverKey: s.serverKey, serverName: s.serverName ?? s.serverKey, assetPk: s.assetPk }]))
+  servers: Object.fromEntries(servers.map((s) => [s.serverKey, { serverName: s.serverName ?? s.serverKey, assetPk: s.assetPk }]))
 })
 
 const statusFor = (name: string, pk: number): AssetStatus => ({ asset: { name, pk } })

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -1,4 +1,4 @@
-import { AssetPositionData, AssetStatus, ServerState, canonicalServerOrigin, getServerURL } from './server'
+import { AssetPositionData, AssetStatus, ServerState, getServerURL } from './server'
 
 export type Command = 'GOTO' | 'ALT' | 'RTL' | 'HOLD' | 'RON' | 'DISARM' | 'TERM' | 'MAN'
 
@@ -8,7 +8,6 @@ export type CommandPayload =
   | { command: Extract<Command, 'RTL' | 'HOLD' | 'RON' | 'DISARM' | 'TERM' | 'MAN'> }
 
 export interface AssetServerState {
-  serverKey: string
   serverName: string
   assetPk: number
   data?: AssetStatus
@@ -30,18 +29,27 @@ export const createAsset = (name: string): AssetState => ({
 
 export const getAssetServerURL = (server: ServerState, assetServer: AssetServerState, path: string) => getServerURL(server, `/assets/${assetServer.assetPk}/${path}`)
 
-export const sendAssetCommand = async (knownServers: Record<string, ServerState>, asset: AssetState, data: CommandPayload) => {
-  const entries: [string, string][] = Object.entries(data).map(([k, v]) => [k, String(v)])
-  const targetsByOrigin = new Map<string, { assetServer: AssetServerState; server: ServerState }>()
-  for (const assetServer of Object.values(asset.servers)) {
-    const server = knownServers[assetServer.serverKey]
+interface AssetTarget {
+  server: ServerState
+  assetServer: AssetServerState
+}
+
+const resolveAssetTargets = (knownServers: Record<string, ServerState>, asset: AssetState): AssetTarget[] => {
+  const targetsByOrigin = new Map<string, AssetTarget>()
+  for (const [serverKey, assetServer] of Object.entries(asset.servers)) {
+    const server = knownServers[serverKey]
     if (!server) continue
-    const origin = canonicalServerOrigin(server.url)
-    if (!targetsByOrigin.has(origin)) {
-      targetsByOrigin.set(origin, { assetServer, server })
+    if (!targetsByOrigin.has(server.url)) {
+      targetsByOrigin.set(server.url, { assetServer, server })
     }
   }
-  const targets = Array.from(targetsByOrigin.values())
+
+  return Array.from(targetsByOrigin.values())
+}
+
+export const sendAssetCommand = async (knownServers: Record<string, ServerState>, asset: AssetState, data: CommandPayload) => {
+  const entries: [string, string][] = Object.entries(data).map(([k, v]) => [k, String(v)])
+  const targets = resolveAssetTargets(knownServers, asset)
   const results = await Promise.allSettled(
     targets.map(({ assetServer, server }) => {
       return fetch(getAssetServerURL(server, assetServer, 'command/set/'), {
@@ -125,7 +133,6 @@ export const mergeServerAssets = (
     const assetName = assetData.asset.name
     const existing = nextAssets[assetName] ?? createAsset(assetName)
     const assetServer: AssetServerState = {
-      serverKey,
       serverName,
       assetPk: assetData.asset.pk,
       data: assetData,

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -1,4 +1,4 @@
-import { AssetPositionData, AssetStatus, ServerState, getServerURL } from './server'
+import { AssetPositionData, AssetStatus, ServerState, canonicalServerOrigin, getServerURL } from './server'
 
 export type Command = 'GOTO' | 'ALT' | 'RTL' | 'HOLD' | 'RON' | 'DISARM' | 'TERM' | 'MAN'
 
@@ -8,6 +8,7 @@ export type CommandPayload =
   | { command: Extract<Command, 'RTL' | 'HOLD' | 'RON' | 'DISARM' | 'TERM' | 'MAN'> }
 
 export interface AssetServerState {
+  serverKey: string
   serverName: string
   assetPk: number
   data?: AssetStatus
@@ -18,7 +19,7 @@ export interface AssetServerState {
 
 export interface AssetState {
   name: string
-  selectedServerName?: string
+  selectedServerKey?: string
   servers: Record<string, AssetServerState>
 }
 
@@ -31,11 +32,18 @@ export const getAssetServerURL = (server: ServerState, assetServer: AssetServerS
 
 export const sendAssetCommand = async (knownServers: Record<string, ServerState>, asset: AssetState, data: CommandPayload) => {
   const entries: [string, string][] = Object.entries(data).map(([k, v]) => [k, String(v)])
-  const assetServers = Object.values(asset.servers)
+  const targetsByOrigin = new Map<string, { assetServer: AssetServerState; server: ServerState }>()
+  for (const assetServer of Object.values(asset.servers)) {
+    const server = knownServers[assetServer.serverKey]
+    if (!server) continue
+    const origin = canonicalServerOrigin(server.url)
+    if (!targetsByOrigin.has(origin)) {
+      targetsByOrigin.set(origin, { assetServer, server })
+    }
+  }
+  const targets = Array.from(targetsByOrigin.values())
   const results = await Promise.allSettled(
-    assetServers.map((assetServer) => {
-      const server = knownServers[assetServer.serverName]
-      if (!server) return Promise.resolve()
+    targets.map(({ assetServer, server }) => {
       return fetch(getAssetServerURL(server, assetServer, 'command/set/'), {
         method: 'POST',
         credentials: 'include',
@@ -51,7 +59,7 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
     })
   )
 
-  const failures = results.map((result, i) => ({ result, serverName: assetServers[i].serverName })).filter(({ result }) => result.status === 'rejected')
+  const failures = results.map((result, i) => ({ result, serverName: targets[i].assetServer.serverName })).filter(({ result }) => result.status === 'rejected')
 
   if (failures.length > 0) {
     const failureMessages = failures
@@ -61,8 +69,8 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
         return `${serverName}: ${msg}`
       })
       .join(', ')
-    const successCount = assetServers.length - failures.length
-    const prefix = successCount > 0 ? `Command was queued on ${successCount} of ${assetServers.length} server(s) — aircraft may already be affected. ` : ''
+    const successCount = targets.length - failures.length
+    const prefix = successCount > 0 ? `Command was queued on ${successCount} of ${targets.length} server(s) — aircraft may already be affected. ` : ''
     throw new Error(`${prefix}Failed on: ${failureMessages}`)
   }
 }
@@ -84,33 +92,40 @@ export const assetPositionMostRecent = (asset: AssetState): AssetPositionData | 
 // asset entirely once that was its last server. Only call this for a
 // server's *successful* poll — a failed/unreachable/unauthenticated poll
 // should leave last-known data + age styling in place instead.
-const pruneStaleServerEntries = (currentAssets: Record<string, AssetState>, serverName: string, reportedNames: Set<string>): Record<string, AssetState> => {
+const pruneStaleServerEntries = (currentAssets: Record<string, AssetState>, serverKey: string, reportedNames: Set<string>): Record<string, AssetState> => {
   const nextAssets = { ...currentAssets }
   for (const [assetName, assetState] of Object.entries(nextAssets)) {
-    if (reportedNames.has(assetName) || !(serverName in assetState.servers)) continue
+    if (reportedNames.has(assetName) || !(serverKey in assetState.servers)) continue
     const remainingServers = { ...assetState.servers }
-    delete remainingServers[serverName]
-    const remainingServerNames = Object.keys(remainingServers)
-    if (remainingServerNames.length === 0) {
+    delete remainingServers[serverKey]
+    const remainingServerKeys = Object.keys(remainingServers)
+    if (remainingServerKeys.length === 0) {
       delete nextAssets[assetName]
     } else {
       nextAssets[assetName] = {
         ...assetState,
         servers: remainingServers,
-        selectedServerName: assetState.selectedServerName === serverName ? remainingServerNames[0] : assetState.selectedServerName
+        selectedServerKey: assetState.selectedServerKey === serverKey ? remainingServerKeys[0] : assetState.selectedServerKey
       }
     }
   }
   return nextAssets
 }
 
-export const mergeServerAssets = (currentAssets: Record<string, AssetState>, serverName: string, assets: AssetStatus[], serverNow?: number): Record<string, AssetState> => {
+export const mergeServerAssets = (
+  currentAssets: Record<string, AssetState>,
+  serverKey: string,
+  serverName: string,
+  assets: AssetStatus[],
+  serverNow?: number
+): Record<string, AssetState> => {
   const reportedNames = new Set(assets.map((assetData) => assetData.asset.name))
-  const nextAssets = pruneStaleServerEntries(currentAssets, serverName, reportedNames)
+  const nextAssets = pruneStaleServerEntries(currentAssets, serverKey, reportedNames)
   for (const assetData of assets) {
     const assetName = assetData.asset.name
     const existing = nextAssets[assetName] ?? createAsset(assetName)
     const assetServer: AssetServerState = {
+      serverKey,
       serverName,
       assetPk: assetData.asset.pk,
       data: assetData,
@@ -118,8 +133,8 @@ export const mergeServerAssets = (currentAssets: Record<string, AssetState>, ser
     }
     nextAssets[assetName] = {
       ...existing,
-      servers: { ...existing.servers, [serverName]: assetServer },
-      selectedServerName: existing.selectedServerName ?? serverName
+      servers: { ...existing.servers, [serverKey]: assetServer },
+      selectedServerKey: existing.selectedServerKey ?? serverKey
     }
   }
   return nextAssets

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -443,15 +443,15 @@ const FSSAssetStatus: React.FC<FSSAssetStatusProps> = ({ asset, setSelected }) =
     setSelected(asset.name, e.currentTarget.name)
   }
 
-  const assetServers = Object.values(asset.servers).filter((s) => s.data)
+  const assetServers = Object.entries(asset.servers).filter(([, server]) => server.data)
 
   return (
     <div className="container card">
       <FSSAssetCommandMisalignment asset={asset} />
       <ul className="nav nav-tabs server-tab-btn">
-        {assetServers.map((server) => (
-          <li className="nav-item" key={server.serverKey}>
-            <button data-toggle="tab" className="nav-link server-tab-btn" name={server.serverKey} onClick={selectServer}>
+        {assetServers.map(([serverKey, server]) => (
+          <li className="nav-item" key={serverKey}>
+            <button data-toggle="tab" className="nav-link server-tab-btn" name={serverKey} onClick={selectServer}>
               {server.serverName}
             </button>
           </li>

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -1,6 +1,6 @@
 import { type Axis, degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
 import { AssetState, AssetServerState, AssetController, createAssetController, mergeServerAssets } from './asset'
-import { ServerState, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, mergeServerPollResult } from './server'
+import { ServerState, canonicalServerOrigin, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, mergeServerPollResult } from './server'
 import {
   assetPositionTimeWarn,
   assetPositionTimeOld,
@@ -293,7 +293,7 @@ const FSSAssetCommandMisalignment: React.FC<{ asset: AssetState }> = ({ asset })
           </thead>
           <tbody>
             {servers.map((s) => (
-              <tr key={s.serverName}>
+              <tr key={s.serverKey}>
                 <td>{s.serverName}</td>
                 <td>{s.commandCode ?? '—'}</td>
                 <td className={s.ack.className}>{s.ack.text}</td>
@@ -450,16 +450,16 @@ const FSSAssetStatus: React.FC<FSSAssetStatusProps> = ({ asset, setSelected }) =
       <FSSAssetCommandMisalignment asset={asset} />
       <ul className="nav nav-tabs server-tab-btn">
         {assetServers.map((server) => (
-          <li className="nav-item" key={server.serverName}>
-            <button data-toggle="tab" className="nav-link server-tab-btn" name={server.serverName} onClick={selectServer}>
+          <li className="nav-item" key={server.serverKey}>
+            <button data-toggle="tab" className="nav-link server-tab-btn" name={server.serverKey} onClick={selectServer}>
               {server.serverName}
             </button>
           </li>
         ))}
       </ul>
       <div className="asset-status">
-        {asset.selectedServerName && asset.servers[asset.selectedServerName] && (
-          <FSSAssetServerStatus server={asset.servers[asset.selectedServerName]} serverLabel={asset.selectedServerName} />
+        {asset.selectedServerKey && asset.servers[asset.selectedServerKey] && (
+          <FSSAssetServerStatus server={asset.servers[asset.selectedServerKey]} serverLabel={asset.servers[asset.selectedServerKey].serverName} />
         )}
       </div>
     </div>
@@ -531,7 +531,7 @@ function FSSServerBar(props: FSSServerBarProps) {
   return (
     <div className="bar-server">
       {knownServers.map((server) => (
-        <FSSServer key={server.name} server={server} />
+        <FSSServer key={server.url} server={server} />
       ))}
     </div>
   )
@@ -539,7 +539,7 @@ function FSSServerBar(props: FSSServerBarProps) {
 
 export const FSSMainPage: React.FC = () => {
   const [knownServers, setKnownServers] = useState<Record<string, ServerState>>({
-    direct: createServer('direct', '127.0.0.1', 0, window.location.origin)
+    [canonicalServerOrigin(window.location.origin)]: createServer('direct', '127.0.0.1', 0, window.location.origin)
   })
   const [knownAssets, setKnownAssets] = useState<Record<string, AssetState>>({})
   const [lastError, setLastError] = useState<string | null>(null)
@@ -559,22 +559,22 @@ export const FSSMainPage: React.FC = () => {
     pollAbortRef.current = ac
 
     const snapshotServers = knownServersRef.current
-    const serverNames = Object.keys(snapshotServers)
+    const serverKeys = Object.keys(snapshotServers)
 
     const results = await Promise.all(
-      serverNames.map(async (serverName) => {
-        const server = snapshotServers[serverName]
+      serverKeys.map(async (serverKey) => {
+        const server = snapshotServers[serverKey]
         // Bound each server's fetch independently so one hung/blackholed peer
         // can't stall the other servers' otherwise-successful data behind it.
         const signal = AbortSignal.any([ac.signal, AbortSignal.timeout(pollFetchTimeoutMs)])
         try {
           const response = await fetch(getServerURL(server, '/current/all.json/'), { credentials: 'include', signal })
-          if (response.status === 403) return { serverName, data: null, unauthenticated: true }
+          if (response.status === 403) return { serverKey, data: null, unauthenticated: true }
           if (!response.ok) throw new Error(`HTTP ${response.status}`)
           const data = await response.json()
-          return { serverName, data, unauthenticated: false }
+          return { serverKey, data, unauthenticated: false }
         } catch {
-          return { serverName, data: null, unauthenticated: false }
+          return { serverKey, data: null, unauthenticated: false }
         }
       })
     )
@@ -588,16 +588,21 @@ export const FSSMainPage: React.FC = () => {
     let currentServers = { ...knownServersRef.current }
     let currentAssets = { ...knownAssetsRef.current }
 
-    for (const { serverName, data, unauthenticated } of results) {
+    for (const { serverKey, data, unauthenticated } of results) {
       if (data === null) {
         if (unauthenticated) {
-          currentServers = { ...currentServers, [serverName]: serverUnauthenticated(currentServers[serverName]) }
+          currentServers = { ...currentServers, [serverKey]: serverUnauthenticated(currentServers[serverKey]) }
         } else {
-          currentServers = { ...currentServers, [serverName]: serverConnectFailed(currentServers[serverName]) }
+          currentServers = { ...currentServers, [serverKey]: serverConnectFailed(currentServers[serverKey]) }
         }
       } else {
-        currentServers = mergeServerPollResult(currentServers, serverName, data)
-        currentAssets = mergeServerAssets(currentAssets, serverName, data.assets, data.server_now)
+        currentServers = mergeServerPollResult(currentServers, serverKey, data)
+      }
+    }
+
+    for (const { serverKey, data } of results) {
+      if (data !== null) {
+        currentAssets = mergeServerAssets(currentAssets, serverKey, currentServers[serverKey].name, data.assets, data.server_now)
       }
     }
 
@@ -616,7 +621,7 @@ export const FSSMainPage: React.FC = () => {
     }
   }, [updateData])
 
-  const setAssetSelectedServer = (assetName: string, serverName: string) => {
+  const setAssetSelectedServer = (assetName: string, serverKey: string) => {
     setKnownAssets((prev) => {
       const asset = prev[assetName]
       if (!asset) return prev
@@ -624,7 +629,7 @@ export const FSSMainPage: React.FC = () => {
         ...prev,
         [assetName]: {
           ...asset,
-          selectedServerName: serverName
+          selectedServerKey: serverKey
         }
       }
     })

--- a/frontend/rendering.test.ts
+++ b/frontend/rendering.test.ts
@@ -29,6 +29,7 @@ const makeCommand = (overrides: Partial<AssetCommandData> = {}): AssetCommandDat
 })
 
 const makeAssetServer = (serverName: string, command: AssetCommandData, serverNow = SERVER_NOW): AssetServerState => ({
+  serverKey: `https://${serverName}.example`,
   serverName,
   assetPk: 1,
   data: { asset: { name: 'Drone', pk: 1 }, command },
@@ -37,7 +38,7 @@ const makeAssetServer = (serverName: string, command: AssetCommandData, serverNo
 
 const makeAsset = (servers: AssetServerState[]): AssetState => ({
   name: 'Drone',
-  servers: Object.fromEntries(servers.map((s) => [s.serverName, s]))
+  servers: Object.fromEntries(servers.map((s) => [s.serverKey, s]))
 })
 
 describe('dataAgeClass', () => {
@@ -212,7 +213,13 @@ describe('assetServerMisalignment', () => {
 
   it('ignores servers with no command data at all', () => {
     const withCommand = makeAssetServer('alpha', makeCommand({ command_code: 'RTL' }))
-    const withoutCommand: AssetServerState = { serverName: 'beta', assetPk: 1, data: { asset: { name: 'Drone', pk: 1 } }, serverNow: SERVER_NOW }
+    const withoutCommand: AssetServerState = {
+      serverKey: 'https://beta.example',
+      serverName: 'beta',
+      assetPk: 1,
+      data: { asset: { name: 'Drone', pk: 1 } },
+      serverNow: SERVER_NOW
+    }
     const asset = makeAsset([withCommand, withoutCommand])
 
     const result = assetServerMisalignment(asset)

--- a/frontend/rendering.test.ts
+++ b/frontend/rendering.test.ts
@@ -29,7 +29,6 @@ const makeCommand = (overrides: Partial<AssetCommandData> = {}): AssetCommandDat
 })
 
 const makeAssetServer = (serverName: string, command: AssetCommandData, serverNow = SERVER_NOW): AssetServerState => ({
-  serverKey: `https://${serverName}.example`,
   serverName,
   assetPk: 1,
   data: { asset: { name: 'Drone', pk: 1 }, command },
@@ -38,7 +37,7 @@ const makeAssetServer = (serverName: string, command: AssetCommandData, serverNo
 
 const makeAsset = (servers: AssetServerState[]): AssetState => ({
   name: 'Drone',
-  servers: Object.fromEntries(servers.map((s) => [s.serverKey, s]))
+  servers: Object.fromEntries(servers.map((s) => [`https://${s.serverName}.example`, s]))
 })
 
 describe('dataAgeClass', () => {
@@ -214,7 +213,6 @@ describe('assetServerMisalignment', () => {
   it('ignores servers with no command data at all', () => {
     const withCommand = makeAssetServer('alpha', makeCommand({ command_code: 'RTL' }))
     const withoutCommand: AssetServerState = {
-      serverKey: 'https://beta.example',
       serverName: 'beta',
       assetPk: 1,
       data: { asset: { name: 'Drone', pk: 1 } },

--- a/frontend/rendering.ts
+++ b/frontend/rendering.ts
@@ -152,6 +152,7 @@ export const commandAckOutcome = (command: AssetCommandData, serverNow?: number)
 
 // Per-server view of an asset's command, for the misalignment indicator.
 export interface ServerCommandView {
+  serverKey: string
   serverName: string
   commandCode?: string
   ack: { text: string; className: string }
@@ -172,6 +173,7 @@ export const assetServerMisalignment = (asset: AssetState): { disagree: boolean;
     const command = assetServer.data?.command
     if (!command) continue
     servers.push({
+      serverKey: assetServer.serverKey,
       serverName: assetServer.serverName,
       commandCode: command.command_code,
       ack: commandAckDisplay(command, assetServer.serverNow),

--- a/frontend/rendering.ts
+++ b/frontend/rendering.ts
@@ -169,11 +169,11 @@ export interface ServerCommandView {
 // there is nothing to disagree about.
 export const assetServerMisalignment = (asset: AssetState): { disagree: boolean; servers: ServerCommandView[] } => {
   const servers: ServerCommandView[] = []
-  for (const assetServer of Object.values(asset.servers)) {
+  for (const [serverKey, assetServer] of Object.entries(asset.servers)) {
     const command = assetServer.data?.command
     if (!command) continue
     servers.push({
-      serverKey: assetServer.serverKey,
+      serverKey,
       serverName: assetServer.serverName,
       commandCode: command.command_code,
       ack: commandAckDisplay(command, assetServer.serverNow),

--- a/frontend/server.test.ts
+++ b/frontend/server.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ServerState, StatusData, createServer, mergeServerPollResult } from './server'
+import { ServerState, StatusData, canonicalServerOrigin, createServer, mergeServerPollResult } from './server'
 
 const statusData = (overrides: Partial<StatusData> = {}): StatusData => ({
   csrfToken: 'tok',
@@ -11,34 +11,68 @@ const statusData = (overrides: Partial<StatusData> = {}): StatusData => ({
 
 describe('mergeServerPollResult', () => {
   it('updates the polled server with the data from its response', () => {
-    const current: Record<string, ServerState> = { alpha: createServer('alpha', '10.0.0.1', 8080, 'https://alpha.example') }
-    const result = mergeServerPollResult(current, 'alpha', statusData({ currentUser: 'pilot', csrfToken: 'fresh', assets: [{ asset: { name: 'Drone', pk: 1 } }] }))
+    const alphaOrigin = canonicalServerOrigin('https://alpha.example')
+    const current: Record<string, ServerState> = { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) }
+    const result = mergeServerPollResult(current, alphaOrigin, statusData({ currentUser: 'pilot', csrfToken: 'fresh', assets: [{ asset: { name: 'Drone', pk: 1 } }] }))
 
-    expect(result.alpha.connected).toBe(true)
-    expect(result.alpha.userName).toBe('pilot')
-    expect(result.alpha.csrfToken).toBe('fresh')
-    expect(result.alpha.assets).toHaveLength(1)
-    expect(result.alpha.status).toBe('Known Assets: 1')
+    expect(result[alphaOrigin].connected).toBe(true)
+    expect(result[alphaOrigin].userName).toBe('pilot')
+    expect(result[alphaOrigin].csrfToken).toBe('fresh')
+    expect(result[alphaOrigin].assets).toHaveLength(1)
+    expect(result[alphaOrigin].status).toBe('Known Assets: 1')
   })
 
   it('discovers servers advertised by the polled server', () => {
-    const current: Record<string, ServerState> = { alpha: createServer('alpha', '10.0.0.1', 8080, 'https://alpha.example') }
-    const result = mergeServerPollResult(current, 'alpha', statusData({ servers: [{ name: 'beta', address: '10.0.0.2', client_port: 9090, url: 'https://beta.example' }] }))
+    const alphaOrigin = canonicalServerOrigin('https://alpha.example')
+    const betaOrigin = canonicalServerOrigin('https://beta.example')
+    const current: Record<string, ServerState> = { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) }
+    const result = mergeServerPollResult(current, alphaOrigin, statusData({ servers: [{ name: 'beta', address: '10.0.0.2', client_port: 9090, url: betaOrigin }] }))
 
-    expect(Object.keys(result).sort()).toEqual(['alpha', 'beta'])
-    expect(result.beta.connected).toBe(false)
-    expect(result.beta.url).toBe('https://beta.example')
-    expect(result.beta.clientPort).toBe(9090)
+    expect(Object.keys(result).sort()).toEqual([alphaOrigin, betaOrigin])
+    expect(result[betaOrigin].connected).toBe(false)
+    expect(result[betaOrigin].url).toBe(betaOrigin)
+    expect(result[betaOrigin].clientPort).toBe(9090)
   })
 
   it('does not clobber an already-known server when it is re-advertised', () => {
+    const alphaOrigin = canonicalServerOrigin('https://alpha.example')
+    const betaOrigin = canonicalServerOrigin('https://beta.example')
     const current: Record<string, ServerState> = {
-      alpha: createServer('alpha', '10.0.0.1', 8080, 'https://alpha.example'),
-      beta: { ...createServer('beta', '10.0.0.2', 9090, 'https://beta.example'), connected: true, userName: 'pilot' }
+      [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin),
+      [betaOrigin]: { ...createServer('beta', '10.0.0.2', 9090, betaOrigin), connected: true, userName: 'pilot' }
     }
-    const result = mergeServerPollResult(current, 'alpha', statusData({ servers: [{ name: 'beta', address: '10.0.0.2', client_port: 9090, url: 'https://beta.example' }] }))
+    const result = mergeServerPollResult(current, alphaOrigin, statusData({ servers: [{ name: 'beta', address: '10.0.0.2', client_port: 9090, url: betaOrigin }] }))
 
-    expect(result.beta.connected).toBe(true)
-    expect(result.beta.userName).toBe('pilot')
+    expect(result[betaOrigin].connected).toBe(true)
+    expect(result[betaOrigin].userName).toBe('pilot')
+  })
+
+  it('collapses the direct alias into an advertised server with the same canonical origin', () => {
+    const localOrigin = canonicalServerOrigin('https://fss1.example')
+    const current: Record<string, ServerState> = {
+      [localOrigin]: createServer('direct', '127.0.0.1', 0, localOrigin)
+    }
+    const result = mergeServerPollResult(
+      current,
+      localOrigin,
+      statusData({ servers: [{ name: 'fss1', address: 'fss1.example', client_port: 20202, url: 'https://FSS1.example:443/' }] })
+    )
+
+    expect(Object.keys(result)).toEqual([localOrigin])
+    expect(result[localOrigin].name).toBe('fss1')
+    expect(result[localOrigin].connected).toBe(true)
+  })
+
+  it('keeps same-named servers on distinct origins separate', () => {
+    const firstOrigin = canonicalServerOrigin('https://fss1.example')
+    const secondOrigin = canonicalServerOrigin('https://fss2.example')
+    const current: Record<string, ServerState> = {
+      [firstOrigin]: createServer('operations', '10.0.0.1', 8080, firstOrigin)
+    }
+    const result = mergeServerPollResult(current, firstOrigin, statusData({ servers: [{ name: 'operations', address: '10.0.0.2', client_port: 9090, url: secondOrigin }] }))
+
+    expect(Object.keys(result).sort()).toEqual([firstOrigin, secondOrigin])
+    expect(result[firstOrigin].url).toBe(firstOrigin)
+    expect(result[secondOrigin].url).toBe(secondOrigin)
   })
 })

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -94,11 +94,17 @@ export interface ServerState {
   servers: Array<ServerDetails>
 }
 
+// Server names are operator-assigned display labels and are not guaranteed to
+// be unique across a fleet. The management origin is the stable identity used
+// by the frontend, with URL normalisation collapsing aliases such as
+// https://fss1.example:443/ and https://fss1.example.
+export const canonicalServerOrigin = (url: string): string => new URL(url).origin
+
 export const createServer = (name: string, address: string, clientPort: number, url: string): ServerState => ({
   name,
   address,
   clientPort,
-  url,
+  url: canonicalServerOrigin(url),
   connected: false,
   status: 'Connecting ...',
   assets: [],
@@ -134,12 +140,16 @@ export const serverUnauthenticated = (server: ServerState): ServerState => ({
   servers: []
 })
 
-export const mergeServerPollResult = (currentServers: Record<string, ServerState>, serverName: string, data: StatusData): Record<string, ServerState> => {
-  const nextServers = { ...currentServers, [serverName]: updateServerData(currentServers[serverName], data) }
+export const mergeServerPollResult = (currentServers: Record<string, ServerState>, serverKey: string, data: StatusData): Record<string, ServerState> => {
+  const nextServers = { ...currentServers, [serverKey]: updateServerData(currentServers[serverKey], data) }
   for (const s of data.servers) {
-    if (!nextServers[s.name]) {
-      nextServers[s.name] = createServer(s.name, s.address, s.client_port, s.url)
-    }
+    const advertised = createServer(s.name, s.address, s.client_port, s.url)
+    const advertisedKey = canonicalServerOrigin(advertised.url)
+    const existing = nextServers[advertisedKey]
+    // Refresh advertised metadata without replacing live poll state. This also
+    // gives the synthetic local "direct" entry its configured display name
+    // once a peer advertises the same origin.
+    nextServers[advertisedKey] = existing ? { ...existing, name: advertised.name, address: advertised.address, clientPort: advertised.clientPort, url: advertised.url } : advertised
   }
   return nextServers
 }

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -144,7 +144,7 @@ export const mergeServerPollResult = (currentServers: Record<string, ServerState
   const nextServers = { ...currentServers, [serverKey]: updateServerData(currentServers[serverKey], data) }
   for (const s of data.servers) {
     const advertised = createServer(s.name, s.address, s.client_port, s.url)
-    const advertisedKey = canonicalServerOrigin(advertised.url)
+    const advertisedKey = advertised.url
     const existing = nextServers[advertisedKey]
     // Refresh advertised metadata without replacing live poll state. This also
     // gives the synthetic local "direct" entry its configured display name


### PR DESCRIPTION
## Description

Server names are mutable display labels and the synthetic direct alias can refer to the same instance under another name. Using normalized management origins as identity prevents duplicate polling and safety-command dispatch while allowing same-named servers at distinct origins.

## Summary by Sourcery

Key frontend server and asset state by canonical URL origin rather than mutable server names to deduplicate polling and command dispatch while preserving support for same-named servers on distinct origins.

Bug Fixes:
- Prevent duplicate command dispatch and polling when the local direct alias and an advertised peer refer to the same server origin.

Enhancements:
- Track asset-to-server associations using stable server keys (canonical origins) while preserving human-readable server display names.
- Normalize server URLs at creation time and during discovery so legacy aliases such as explicit :443 variants collapse to a single server entry.
- Adjust frontend components and tests to use server keys instead of names for selection, rendering, and command status misalignment logic.

Documentation:
- Document the change in server identity handling and alias collapsing in the changelog.