### PR TITLE
feat(commands): enforce destructive confirmation tokens

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -2,9 +2,11 @@
 Tests for the Asset API
 """
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
+from django.db import IntegrityError
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -23,6 +25,14 @@ class AssetAPITest(TestCase):
         self.client = Client()
         self.asset = Asset.objects.create(name='Test Drone')
         self.user = get_user_model().objects.create_user(username='testuser', password='testpass')
+
+    def _issue_confirmation(self, command, *, asset=None, client=None):
+        target_asset = asset or self.asset
+        target_client = client or self.client
+        url = reverse('asset_command_confirm', kwargs={'asset_id': target_asset.pk})
+        response = target_client.post(url, {'command': command})
+        self.assertEqual(response.status_code, 200)
+        return response.json()['confirmation_token']
 
     def test_asset_command_set_unauthenticated(self):
         """Test that unauthenticated command attempts are rejected."""
@@ -92,7 +102,8 @@ class AssetAPITest(TestCase):
         """The issuing user is recorded on the command and surfaced in the API."""
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        self.client.post(url, {'command': 'TERM'})
+        token = self._issue_confirmation('TERM')
+        self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
 
         cmd = AssetCommand.objects.filter(asset=self.asset).latest('timestamp')
         self.assertEqual(cmd.issued_by, self.user)
@@ -100,6 +111,110 @@ class AssetAPITest(TestCase):
         status_url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
         data = self.client.get(status_url).json()
         self.assertEqual(data['command']['issued_by'], 'testuser')
+
+    @satisfies('TC-WEB-010')
+    def test_disarm_requires_single_use_confirmation(self):
+        """DISARM requires confirmation evidence and consumes it on success."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+
+        response = self.client.post(url, {'command': 'DISARM'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+
+        token = self._issue_confirmation('DISARM')
+        response = self.client.post(url, {'command': 'DISARM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AssetCommand.objects.filter(command='DISARM').count(), 1)
+        self.assertFalse(AssetCommandConfirmation.objects.filter(token=token).exists())
+
+        response = self.client.post(url, {'command': 'DISARM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(AssetCommand.objects.filter(command='DISARM').count(), 1)
+
+    @satisfies('TC-WEB-011')
+    def test_term_requires_single_use_confirmation(self):
+        """TERM requires confirmation evidence and consumes it on success."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+
+        response = self.client.post(url, {'command': 'TERM'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+
+        token = self._issue_confirmation('TERM')
+        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AssetCommand.objects.filter(command='TERM').count(), 1)
+        self.assertFalse(AssetCommandConfirmation.objects.filter(token=token).exists())
+
+    def test_asset_command_set_rejects_expired_confirmation(self):
+        """An expired destructive-command confirmation cannot queue a command."""
+        self.client.force_login(self.user)
+        token = self._issue_confirmation('TERM')
+        AssetCommandConfirmation.objects.filter(token=token).update(expires_at=timezone.now() - timedelta(seconds=1))
+
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+
+    def test_asset_command_set_rejects_malformed_confirmation(self):
+        """A malformed token is a validation failure, not a server error."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': 'not-a-uuid'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+
+    def test_asset_command_set_rejects_confirmation_for_other_user(self):
+        """A token cannot be transferred to another authenticated user."""
+        self.client.force_login(self.user)
+        token = self._issue_confirmation('TERM')
+        other_user = get_user_model().objects.create_user(username='other', password='testpass')
+        self.client.force_login(other_user)
+
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+        self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
+
+    def test_asset_command_set_rejects_confirmation_for_other_asset(self):
+        """A token cannot be used against a different asset."""
+        self.client.force_login(self.user)
+        token = self._issue_confirmation('TERM')
+        other_asset = Asset.objects.create(name='Other Drone')
+
+        url = reverse('asset_command_set', kwargs={'asset_id': other_asset.pk})
+        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+        self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
+
+    def test_asset_command_set_rejects_confirmation_for_other_command(self):
+        """A DISARM confirmation cannot authorize TERM."""
+        self.client.force_login(self.user)
+        token = self._issue_confirmation('DISARM')
+
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+        self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
+
+    def test_asset_command_and_confirmation_consumption_are_atomic(self):
+        """A failure while consuming evidence rolls back the queued command."""
+        self.client.force_login(self.user)
+        token = self._issue_confirmation('TERM')
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+
+        with patch.object(AssetCommandConfirmation, 'delete', side_effect=IntegrityError):
+            with self.assertRaises(IntegrityError):
+                self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+
+        self.assertFalse(AssetCommand.objects.exists())
+        self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
 
     def test_asset_command_set_goto(self):
         """Test setting GOTO command with coordinates."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -6,8 +6,8 @@ import contextlib
 from datetime import timedelta
 
 from django.contrib.gis.geos import Point
-from django.core.exceptions import ObjectDoesNotExist
-from django.db import IntegrityError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import IntegrityError, transaction
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -353,6 +353,28 @@ def asset_command_confirm(request, asset_id):
     })
 
 
+def _queue_destructive_command(asset_command, user, confirmation_token):
+    """
+    Consume matching confirmation evidence and queue its command atomically.
+    """
+    try:
+        with transaction.atomic():
+            confirmation = AssetCommandConfirmation.objects.select_for_update().filter(
+                token=confirmation_token,
+                user=user,
+                asset=asset_command.asset,
+                command=asset_command.command,
+                expires_at__gt=timezone.now(),
+            ).first()
+            if confirmation is None:
+                return False
+            asset_command.save()
+            confirmation.delete()
+    except (TypeError, ValidationError, ValueError):
+        return False
+    return True
+
+
 @login_required_api
 def asset_command_set(request, asset_id):
     """
@@ -391,7 +413,12 @@ def asset_command_set(request, asset_id):
         asset_command = AssetCommand(asset=asset, command=command,
                                      position=point, altitude=altitude,
                                      issued_by=issued_by)
-        asset_command.save()
+        if command in AssetCommand.DESTRUCTIVE_COMMANDS:
+            confirmation_token = request.POST.get('confirmation_token')
+            if not _queue_destructive_command(asset_command, request.user, confirmation_token):
+                return HttpResponseBadRequest("Valid confirmation required")
+        else:
+            asset_command.save()
         return HttpResponse("Queued")
     return HttpResponseBadRequest("Only POST is supported")
 

--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -55,6 +55,70 @@ describe('sendAssetCommand', () => {
     expect(body.get('longitude')).toBe('172.6')
   })
 
+  it('prepares destructive commands and submits the returned token', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ confirmation_token: 'confirm-123' })
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha', 'csrf-123') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 42 }])
+
+    await sendAssetCommand(servers, asset, { command: 'TERM' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://alpha.example/assets/42/command/confirm/')
+    expect((fetchMock.mock.calls[0][1].body as URLSearchParams).get('command')).toBe('TERM')
+    expect(fetchMock.mock.calls[1][0]).toBe('https://alpha.example/assets/42/command/set/')
+    const commandBody = fetchMock.mock.calls[1][1].body as URLSearchParams
+    expect(commandBody.get('command')).toBe('TERM')
+    expect(commandBody.get('confirmation_token')).toBe('confirm-123')
+  })
+
+  it('uses a separate confirmation token for each server target', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith('/command/confirm/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ confirmation_token: url.includes('alpha') ? 'alpha-token' : 'beta-token' })
+        }
+      }
+      return { ok: true, status: 200 }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha'), beta: makeServer('beta') }
+    const asset = makeAsset('Drone', [
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'beta', assetPk: 2 }
+    ])
+
+    await sendAssetCommand(servers, asset, { command: 'DISARM' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    const setRequests = fetchMock.mock.calls.filter((call) => (call[0] as string).endsWith('/command/set/'))
+    expect((setRequests.find((call) => (call[0] as string).includes('alpha'))![1].body as URLSearchParams).get('confirmation_token')).toBe('alpha-token')
+    expect((setRequests.find((call) => (call[0] as string).includes('beta'))![1].body as URLSearchParams).get('confirmation_token')).toBe('beta-token')
+  })
+
+  it('does not submit a destructive command when confirmation fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1 }])
+
+    await expect(sendAssetCommand(servers, asset, { command: 'TERM' })).rejects.toThrow(/alpha: 500 Server Error/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://alpha.example/assets/1/command/confirm/')
+  })
+
   it('dispatches to every server the asset is known on', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
     vi.stubGlobal('fetch', fetchMock)

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -1,6 +1,7 @@
 import { AssetPositionData, AssetStatus, ServerState, getServerURL } from './server'
 
 export type Command = 'GOTO' | 'ALT' | 'RTL' | 'HOLD' | 'RON' | 'DISARM' | 'TERM' | 'MAN'
+type DestructiveCommand = Extract<Command, 'DISARM' | 'TERM'>
 
 export type CommandPayload =
   | { command: 'GOTO'; latitude: number; longitude: number }
@@ -34,6 +35,8 @@ interface AssetTarget {
   assetServer: AssetServerState
 }
 
+const isDestructiveCommand = (command: Command): command is DestructiveCommand => command === 'DISARM' || command === 'TERM'
+
 const resolveAssetTargets = (knownServers: Record<string, ServerState>, asset: AssetState): AssetTarget[] => {
   const targetsByOrigin = new Map<string, AssetTarget>()
   for (const [serverKey, assetServer] of Object.entries(asset.servers)) {
@@ -51,19 +54,32 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
   const entries: [string, string][] = Object.entries(data).map(([k, v]) => [k, String(v)])
   const targets = resolveAssetTargets(knownServers, asset)
   const results = await Promise.allSettled(
-    targets.map(({ assetServer, server }) => {
-      return fetch(getAssetServerURL(server, assetServer, 'command/set/'), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-          'X-CSRFToken': server.csrfToken ?? ''
-        },
-        body: new URLSearchParams(entries)
-      }).then((r) => {
-        if (r.status === 403) throw new Error('not authenticated — please refresh and log in')
-        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
-      })
+    targets.map(async ({ assetServer, server }) => {
+      const post = (path: string, bodyEntries: [string, string][]) =>
+        fetch(getAssetServerURL(server, assetServer, path), {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+            'X-CSRFToken': server.csrfToken ?? ''
+          },
+          body: new URLSearchParams(bodyEntries)
+        }).then((response) => {
+          if (response.status === 403) throw new Error('not authenticated — please refresh and log in')
+          if (!response.ok) throw new Error(`${response.status} ${response.statusText}`)
+          return response
+        })
+
+      let commandEntries = entries
+      if (isDestructiveCommand(data.command)) {
+        const confirmationResponse = await post('command/confirm/', [['command', data.command]])
+        const confirmation = (await confirmationResponse.json()) as { confirmation_token?: unknown }
+        if (typeof confirmation.confirmation_token !== 'string') {
+          throw new Error('server returned an invalid confirmation token')
+        }
+        commandEntries = [...entries, ['confirmation_token', confirmation.confirmation_token]]
+      }
+      await post('command/set/', commandEntries)
     })
   )
 


### PR DESCRIPTION
## Description

A confirmation token has no safety value unless destructive submissions require and atomically consume it. Make each peer server prepare its own token before dispatch while preserving routine-command behavior and partial-failure reporting.

## Summary by Sourcery

Enforce single-use, user- and asset-specific confirmation tokens for destructive asset commands and ensure their atomic consumption with command queuing.

Bug Fixes:
- Prevent destructive commands from being queued without valid, non-expired confirmation evidence and roll back commands when token consumption fails.

Enhancements:
- Require DISARM and TERM commands to use per-server confirmation tokens obtained via a dedicated confirmation endpoint before dispatch.
- Treat malformed or mismatched confirmation tokens as validation failures rather than server errors.

Tests:
- Add backend tests covering confirmation token issuance, single-use semantics, expiry, ownership and asset/command binding, and atomic consumption behavior.
- Extend frontend tests to verify per-server confirmation workflows, token submission for destructive commands, and failure handling when confirmation cannot be obtained.