### PR TITLE
security: expire operator sessions after one shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- **Server-side destructive-command confirmation** — `DISARM` and `TERM` now require a 60-second, single-use confirmation token bound to the authenticated user, asset, and exact command. Multi-server clients prepare and consume an independent token on each peer, and direct or replayed command submissions are rejected without creating a command.
+- **Operator session expiry** — authenticated sessions now use an eight-hour request-sliding lifetime and a browser-session cookie. Expired sessions receive the API's authentication `403` and cannot create commands.
+
 ## 1.0.0 — 2026-05-17
 
 First production release.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ are marked `Secure` in production (`SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`
 so they will not be transmitted over plain HTTP at all. Serving any instance
 over HTTP means operators cannot log in and no commands can be sent.
 
+### Operator sessions expire after eight hours
+
+Operator sessions use an eight-hour sliding expiry and a browser-session
+cookie. Each request refreshes the eight-hour window, and closing the browser
+normally removes the cookie. Because the status UI polls automatically, an
+open tab counts as activity and can keep its session authenticated
+indefinitely; operators must close the browser when leaving a console
+unattended.
+
 ### Multi-server deployments must share a registered domain
 
 When running more than one FSS web instance (for redundancy), every instance

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -4,8 +4,10 @@ Tests for the Asset API
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
+from django.contrib.sessions.models import Session
 from django.db import IntegrityError
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -39,6 +41,45 @@ class AssetAPITest(TestCase):
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
         response = self.client.post(url, {'command': 'RTL'})
         self.assertEqual(response.status_code, 403)
+
+    @satisfies('TC-WEB-014')
+    def test_asset_command_set_rejects_expired_session(self):
+        """An expired operator session cannot create a command."""
+        self.client.force_login(self.user)
+        session_key = self.client.cookies[settings.SESSION_COOKIE_NAME].value
+        Session.objects.filter(session_key=session_key).update(
+            expire_date=timezone.now() - timedelta(seconds=1),
+        )
+
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(url, {'command': 'RTL'})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(AssetCommand.objects.exists())
+
+    def test_authenticated_activity_refreshes_session_expiry(self):
+        """A request within the session window extends command authority."""
+        self.client.force_login(self.user)
+        session_key = self.client.cookies[settings.SESSION_COOKIE_NAME].value
+        previous_expiry = timezone.now() + timedelta(minutes=5)
+        Session.objects.filter(session_key=session_key).update(
+            expire_date=previous_expiry,
+        )
+
+        status_url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        activity_time = timezone.now()
+        response = self.client.get(status_url)
+
+        self.assertEqual(response.status_code, 200)
+        refreshed_expiry = Session.objects.get(session_key=session_key).expire_date
+        expected_expiry = activity_time + timedelta(seconds=settings.SESSION_COOKIE_AGE)
+        self.assertGreater(refreshed_expiry, previous_expiry)
+        self.assertLess(abs(refreshed_expiry - expected_expiry), timedelta(seconds=5))
+
+        command_url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        response = self.client.post(command_url, {'command': 'RTL'})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(AssetCommand.objects.filter(asset=self.asset, command='RTL').exists())
 
     def test_asset_command_confirm_unauthenticated(self):
         """Test that unauthenticated confirmation attempts are rejected."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -434,7 +434,11 @@ def asset_add(request):
     if asset_name is None:
         return HttpResponseBadRequest("Missing asset_name")
     try:
-        Asset.objects.create(name=asset_name)
+        # Contain the expected uniqueness failure in a savepoint. This keeps
+        # the surrounding request transaction usable when session middleware
+        # persists the sliding expiry after the view returns.
+        with transaction.atomic():
+            Asset.objects.create(name=asset_name)
     except IntegrityError:
         # Relies on Asset.name's unique constraint rather than a racy
         # exists()-then-save() check, so two concurrent requests for the same

--- a/fss/settings.py
+++ b/fss/settings.py
@@ -33,6 +33,14 @@ globals().setdefault('SESSION_COOKIE_SECURE', True)
 globals().setdefault('CSRF_COOKIE_SECURE', True)
 globals().setdefault('SESSION_COOKIE_SAMESITE', 'Lax')
 globals().setdefault('CSRF_COOKIE_SAMESITE', 'Lax')
+# Keep authenticated command authority within an operational shift. Saving on
+# every request makes this an inactivity timeout rather than an absolute
+# lifetime, while a session cookie prevents credentials persisting across a
+# normal browser restart. Site-specific settings may deliberately tighten
+# these defaults.
+globals().setdefault('SESSION_COOKIE_AGE', 8 * 60 * 60)
+globals().setdefault('SESSION_SAVE_EVERY_REQUEST', True)
+globals().setdefault('SESSION_EXPIRE_AT_BROWSER_CLOSE', True)
 
 
 def merge_csrf_trusted_origins(csrf_trusted, cors_allowed):

--- a/main/tests/test_security_settings.py
+++ b/main/tests/test_security_settings.py
@@ -22,6 +22,12 @@ class SecuritySettingsTest(SimpleTestCase):
         self.assertEqual(settings.SESSION_COOKIE_SAMESITE, 'Lax')
         self.assertEqual(settings.CSRF_COOKIE_SAMESITE, 'Lax')
 
+    def test_operator_sessions_use_sliding_shift_length_expiry(self):
+        """Operator sessions are browser-bound and expire after eight idle hours."""
+        self.assertEqual(settings.SESSION_COOKIE_AGE, 8 * 60 * 60)
+        self.assertTrue(settings.SESSION_SAVE_EVERY_REQUEST)
+        self.assertTrue(settings.SESSION_EXPIRE_AT_BROWSER_CLOSE)
+
     def test_cors_allows_only_peer_poll_and_command_routes(self):
         """Peer servers can prepare and submit commands, but not read unrelated APIs."""
         self.assertRegex('/current/all.json/', settings.CORS_URLS_REGEX)


### PR DESCRIPTION
## Description

Command authority should not retain Django's two-week default lifetime. Apply an overridable eight-hour request-sliding policy with browser-close expiry, and prove expired sessions cannot enqueue commands while valid activity renews access.

## Summary by Sourcery

Enforce an eight-hour, sliding, browser-bound expiry for operator sessions and ensure expired sessions cannot issue asset commands while valid activity renews access.

New Features:
- Apply an eight-hour request-sliding session policy with browser-close expiry for authenticated operator sessions.

Enhancements:
- Wrap asset creation in a transaction savepoint to keep the request transaction usable when session middleware persists updated session expiry.

Documentation:
- Document the eight-hour sliding operator session policy and the need to close browsers when leaving consoles unattended.

Tests:
- Add tests confirming expired sessions are rejected from creating asset commands and that authenticated activity refreshes session expiry.
- Add configuration tests asserting the new session expiry, sliding behavior, and browser-close settings are enabled by default.

Chores:
- Update the changelog to describe operator session expiry and related security behavior.