### PR TITLE
security: throttle repeated login failures

### DIFF
--- a/fss/security.py
+++ b/fss/security.py
@@ -1,0 +1,42 @@
+"""
+Authentication security integration helpers.
+"""
+
+import logging
+
+from axes.signals import user_locked_out
+from django.dispatch import receiver
+from django.http import HttpResponseBase
+from django.shortcuts import redirect
+
+LOGGER = logging.getLogger('fss.security')
+
+
+def ignore_client_ip(_request):
+    """
+    Do not collect an address that is not part of the lockout policy.
+
+    Deployments use independently configured reverse proxies, so Django
+    cannot safely interpret a forwarded client-address header globally.
+    """
+    return None
+
+
+def preserve_auth_failure_response(_request, response, _credentials, *args, **kwargs):
+    """
+    Keep the login view's generic failure response when Axes blocks a login.
+    """
+    if isinstance(response, HttpResponseBase):
+        return response
+    # django-axes 8.3.1 does not pass the original response through its async
+    # middleware path. Keep that edge case generic instead of returning its
+    # credentials dictionary as a response.
+    return redirect('/login/?error=1')
+
+
+@receiver(user_locked_out)
+def log_user_lockout(sender, request, username, ip_address, **kwargs):  # pylint: disable=unused-argument
+    """
+    Emit an operational security event without credentials or request data.
+    """
+    LOGGER.warning("Login temporarily locked for username %r", username)

--- a/fss/settings.py
+++ b/fss/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 """
 
 import os
+from datetime import timedelta
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -78,6 +79,7 @@ INSTALLED_APPS = [
     'config',
     'assets',
     'main',
+    'axes',
     'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -96,7 +98,36 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'axes.middleware.AxesMiddleware',
 ]
+
+AUTHENTICATION_BACKENDS = [
+    'axes.backends.AxesStandaloneBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+# Authentication credentials grant safety-critical command authority. Track
+# repeated failures in the database by submitted username, independent of
+# client IP, and temporarily block that username after five failures in a
+# rolling fifteen-minute window. Successful authentication starts a fresh
+# window. The custom lockout callable preserves each login view's normal
+# generic failure response instead of revealing whether a lockout exists.
+AXES_FAILURE_LIMIT = 5
+AXES_COOLOFF_TIME = timedelta(minutes=15)
+AXES_USE_ATTEMPT_EXPIRATION = True
+AXES_RESET_ON_SUCCESS = True
+# Retrying during an active lockout must not extend it indefinitely.
+AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT = False
+AXES_LOCKOUT_PARAMETERS = ['username']
+AXES_CLIENT_IP_CALLABLE = 'fss.security.ignore_client_ip'
+AXES_LOCKOUT_CALLABLE = 'fss.security.preserve_auth_failure_response'
+# Axes warns whenever IP is absent even for username-only aggregation. That is
+# deliberate here: trusting forwarded addresses without a standardized proxy
+# would let clients evade IP limits, while REMOTE_ADDR would lock every
+# operator behind the same proxy. Preserve deployment-specific check silences.
+SILENCED_SYSTEM_CHECKS = sorted(set(
+    globals().get('SILENCED_SYSTEM_CHECKS', [])
+) | {'axes.W006'})
 
 ROOT_URLCONF = 'fss.urls'
 

--- a/fss/test_settings.py
+++ b/fss/test_settings.py
@@ -14,3 +14,8 @@ DATABASES = {
 
 # Ensure we don't try to connect to a real Postgres in tests
 SPATIALITE_LIBRARY_PATH = 'mod_spatialite.so'
+
+# Most tests authenticate directly through Client.login(), which does not pass
+# an HttpRequest to authentication backends. Enable Axes only in the dedicated
+# login-security tests that exercise the real HTTP login view.
+AXES_ENABLED = False

--- a/fss/test_settings_postgis.py
+++ b/fss/test_settings_postgis.py
@@ -8,8 +8,10 @@ CI can point this at a postgis service container; see
 
 import os
 
+# Inherit test-only overrides (including authentication-backend compatibility)
+# and replace only the database engine and connection below.
 # pylint: disable=W0401,W0614
-from .settings import *
+from .test_settings import *
 
 DATABASES = {
     'default': {

--- a/main/apps.py
+++ b/main/apps.py
@@ -9,3 +9,10 @@ class MainConfig(AppConfig):
     Define the Main app
     """
     name = 'main'
+
+    def ready(self):
+        """
+        Register authentication security signal handlers.
+        """
+        # pylint: disable=unused-import,import-outside-toplevel
+        from fss import security

--- a/main/tests/test_login_security.py
+++ b/main/tests/test_login_security.py
@@ -1,0 +1,149 @@
+"""
+Tests for failed-login throttling.
+"""
+
+from datetime import timedelta
+
+from axes.models import AccessAttempt, AccessAttemptExpiration
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+
+@override_settings(AXES_ENABLED=True)
+class LoginRateLimitTest(TestCase):
+    """
+    Repeated failures temporarily block a submitted username on this server.
+    """
+
+    def setUp(self):
+        self.url = reverse('login_page')
+        self.user = get_user_model().objects.create_user(
+            username='testuser',
+            password='password',
+        )
+        self.other_user = get_user_model().objects.create_user(
+            username='otheruser',
+            password='other-password',
+        )
+
+    def assert_generic_failure(self, response):
+        """Failures and lockouts expose the same browser response."""
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/login/?error=1')
+
+    def fail_login(self, client=None, username='testuser', **request_headers):
+        """Submit one bad password and assert the generic response."""
+        client = client or self.client
+        response = client.post(
+            self.url,
+            {'username': username, 'password': 'wrong-password'},
+            **request_headers,
+        )
+        self.assert_generic_failure(response)
+        return response
+
+    def test_fifth_failure_locks_username_and_correct_password_stays_generic(self):
+        """Five failures block authentication without revealing the lockout."""
+        for _index in range(4):
+            self.fail_login()
+
+        with self.assertLogs('fss.security', level='WARNING') as security_logs:
+            self.fail_login()
+
+        self.assertIn(
+            "Login temporarily locked for username 'testuser'",
+            security_logs.output[0],
+        )
+        attempt = AccessAttempt.objects.get(username='testuser')
+        self.assertEqual(attempt.failures_since_start, 5)
+
+        response = self.client.post(
+            self.url,
+            {'username': 'testuser', 'password': 'password'},
+        )
+        self.assert_generic_failure(response)
+        self.assertNotIn('_auth_user_id', self.client.session)
+        attempt.refresh_from_db()
+        self.assertEqual(attempt.failures_since_start, 5)
+
+    def test_username_limit_aggregates_across_client_metadata(self):
+        """Changing addresses, user agents, or cookies does not evade the limit."""
+        for index in range(5):
+            client = Client()
+            self.fail_login(
+                client,
+                REMOTE_ADDR=f'192.0.2.{index + 1}',
+                HTTP_USER_AGENT=f'rotating-agent-{index}',
+            )
+
+        self.assertEqual(
+            sum(
+                AccessAttempt.objects.filter(username='testuser')
+                .values_list('failures_since_start', flat=True)
+            ),
+            5,
+        )
+        response = Client().post(
+            self.url,
+            {'username': 'testuser', 'password': 'password'},
+            REMOTE_ADDR='198.51.100.1',
+            HTTP_USER_AGENT='another-agent',
+        )
+        self.assert_generic_failure(response)
+
+        other_response = Client().post(
+            self.url,
+            {'username': 'otheruser', 'password': 'other-password'},
+            REMOTE_ADDR='198.51.100.1',
+            HTTP_USER_AGENT='another-agent',
+        )
+        self.assertEqual(other_response.status_code, 302)
+        self.assertEqual(other_response.url, '/')
+
+    def test_successful_login_resets_prior_failures(self):
+        """A valid login starts a fresh failure window."""
+        for _index in range(4):
+            self.fail_login()
+
+        response = self.client.post(
+            self.url,
+            {'username': 'testuser', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')
+        self.assertFalse(AccessAttempt.objects.filter(username='testuser').exists())
+
+        self.client.logout()
+        for _index in range(4):
+            self.fail_login()
+
+        response = self.client.post(
+            self.url,
+            {'username': 'testuser', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')
+
+    def test_expired_failure_window_allows_login(self):
+        """Authentication resumes when the rolling cool-off has elapsed."""
+        for _index in range(5):
+            self.fail_login()
+
+        expired_at = timezone.now() - timedelta(minutes=16)
+        AccessAttempt.objects.filter(username='testuser').update(
+            attempt_time=expired_at,
+        )
+        AccessAttemptExpiration.objects.filter(
+            access_attempt__username='testuser',
+        ).update(expires_at=expired_at)
+
+        response = self.client.post(
+            self.url,
+            {'username': 'testuser', 'password': 'password'},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')
+        self.assertIn('_auth_user_id', self.client.session)
+        self.assertFalse(AccessAttempt.objects.filter(username='testuser').exists())

--- a/main/tests/test_security_settings.py
+++ b/main/tests/test_security_settings.py
@@ -2,6 +2,8 @@
 Tests for security-relevant Django settings.
 """
 
+from datetime import timedelta
+
 from django.conf import settings
 from django.test import Client, SimpleTestCase, TestCase, override_settings
 
@@ -27,6 +29,15 @@ class SecuritySettingsTest(SimpleTestCase):
         self.assertEqual(settings.SESSION_COOKIE_AGE, 8 * 60 * 60)
         self.assertTrue(settings.SESSION_SAVE_EVERY_REQUEST)
         self.assertTrue(settings.SESSION_EXPIRE_AT_BROWSER_CLOSE)
+
+    def test_login_failures_use_username_only_rolling_lockout(self):
+        """Credential failures are bounded without trusting proxy IP headers."""
+        self.assertEqual(settings.AXES_FAILURE_LIMIT, 5)
+        self.assertEqual(settings.AXES_COOLOFF_TIME, timedelta(minutes=15))
+        self.assertEqual(settings.AXES_LOCKOUT_PARAMETERS, ['username'])
+        self.assertTrue(settings.AXES_USE_ATTEMPT_EXPIRATION)
+        self.assertTrue(settings.AXES_RESET_ON_SUCCESS)
+        self.assertFalse(settings.AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT)
 
     def test_cors_allows_only_peer_poll_and_command_routes(self):
         """Peer servers can prepare and submit commands, but not read unrelated APIs."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ django==6.0.7
 
 django-cors-headers==4.9.0
 
+django-axes==8.3.1
+
 psycopg[binary,pool]==3.3.4
 
 uwsgi==2.0.31


### PR DESCRIPTION
## Description

Operator credentials grant aircraft command authority, so unlimited authentication attempts are unacceptable. Enforce a per-server username lockout after five failures in fifteen minutes while preserving generic login responses, and cover lockout, reset, expiry, and metadata-rotation behavior.

## Summary by Sourcery

Introduce server-side throttling of repeated login failures to temporarily lock usernames while preserving generic authentication responses.

New Features:
- Add per-username failed-login rate limiting using django-axes to temporarily block authentication after multiple failures.
- Log operational security events when a username becomes locked out without exposing credential details.

Enhancements:
- Configure authentication backends and middleware to integrate django-axes while avoiding reliance on client IP metadata.
- Provide helpers to keep lockout behavior consistent with generic login failure UX and deployment-specific proxy configurations.

Build:
- Add django-axes as a project dependency and configure related settings for production and test environments.

Tests:
- Add integration tests covering username-based lockout behavior, aggregation across client metadata, successful-login resets, and expiry of the failure window.
- Extend security settings tests to validate django-axes configuration and lockout policy behavior.