### PR TITLE
docs: close login rate limiting todo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Server-side destructive-command confirmation** — `DISARM` and `TERM` now require a 60-second, single-use confirmation token bound to the authenticated user, asset, and exact command. Multi-server clients prepare and consume an independent token on each peer, and direct or replayed command submissions are rejected without creating a command.
 - **Operator session expiry** — authenticated sessions now use an eight-hour request-sliding lifetime and a browser-session cookie. Expired sessions receive the API's authentication `403` and cannot create commands.
+- **Login failure throttling** — each server now temporarily locks a submitted username after five failed authentications in a rolling 15-minute window. Lockout responses remain indistinguishable from invalid credentials, retries do not extend the lockout, and operators can inspect or clear attempts through Django Axes.
 
 ## 1.0.0 — 2026-05-17
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ open tab counts as activity and can keep its session authenticated
 indefinitely; operators must close the browser when leaving a console
 unattended.
 
+### Failed logins are temporarily locked
+
+Each FSS web instance tracks failed authentication by submitted username. Five
+failures within a rolling 15-minute window temporarily lock that username on
+that instance. A successful login before the limit resets the failures.
+Attempts made during a lockout do not extend it.
+
+The login page always shows the same `Invalid username or password` message,
+including during a lockout. Current failures and successful access records are
+available through the Django admin's Axes pages, and lockouts emit a warning to
+the application log. An administrator can clear a username before the cool-off
+expires with:
+
+```bash
+./manage.py axes_reset_username USERNAME
+```
+
+In a multi-server deployment, each peer stores its own failure counter in its
+own PostgreSQL database. The five-attempt limit therefore applies separately
+on every peer, and an administrator must run the reset on every peer where the
+username is locked. Deployments that require one aggregate threshold across
+all peers must additionally enforce it at a shared, trusted reverse proxy.
+
 ### Multi-server deployments must share a registered domain
 
 When running more than one FSS web instance (for redundancy), every instance


### PR DESCRIPTION
## Description

Operators need the exact lockout and recovery policy, especially because redundant peers keep independent counters. Document inspection and reset procedures, record the cross-peer limitation, and move SECURITY-03 to the completed backlog.

## Summary by Sourcery

Document the login failure lockout behavior and its operational implications for multi-server deployments.

Documentation:
- Add operator-facing documentation for username lockout thresholds, durations, and reset procedures, including Django Axes inspection and clearing.
- Clarify that failed login counters and lockouts are tracked independently per server and require per-peer resets, with guidance for enforcing aggregate limits via a reverse proxy.

Chores:
- Record the login failure throttling feature in the changelog as a completed capability.