### PR TITLE
feat(commands): block disconnected asset submissions

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from assets.models import Asset, AssetCommand, AssetCommandConfirmation, AssetPosition, AssetRTT, AssetSearchProgress, AssetStatus
-from assets.views import COMMAND_CONFIRMATION_TTL, RTT_SAMPLE_LIMIT, RTT_SCAN_WINDOW, bulk_asset_status_data
+from assets.views import ASSET_CONNECTION_TIMEOUT, COMMAND_CONFIRMATION_TTL, RTT_SAMPLE_LIMIT, RTT_SCAN_WINDOW, bulk_asset_status_data
 from fss.satisfies import satisfies
 
 
@@ -27,6 +27,7 @@ class AssetAPITest(TestCase):
         self.client = Client()
         self.asset = Asset.objects.create(name='Test Drone')
         self.user = get_user_model().objects.create_user(username='testuser', password='testpass')
+        AssetRTT.objects.create(asset=self.asset, rtt=10)
 
     def _issue_confirmation(self, command, *, asset=None, client=None):
         target_asset = asset or self.asset
@@ -138,6 +139,42 @@ class AssetAPITest(TestCase):
         self.assertEqual(cmd.command, 'RTL')
         self.assertEqual(cmd.issued_by, self.user)
 
+    @satisfies('TC-WEB-013')
+    def test_asset_command_set_blocks_asset_without_rtt(self):
+        """An asset that has never answered an RTT cannot be commanded."""
+        self.client.force_login(self.user)
+        AssetRTT.objects.filter(asset=self.asset).delete()
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+
+        response = self.client.post(url, {'command': 'RTL'})
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.content.decode(), 'Asset is disconnected: no recent RTT response')
+        self.assertFalse(AssetCommand.objects.exists())
+
+    @satisfies('TC-WEB-013')
+    def test_asset_command_set_uses_recent_rtt_boundary(self):
+        """A recent RTT permits a command; one outside the grace window blocks it."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        rtt = AssetRTT.objects.get(asset=self.asset)
+        rtt.timestamp = timezone.now() - ASSET_CONNECTION_TIMEOUT + timedelta(seconds=5)
+        rtt.save(update_fields=['timestamp'])
+
+        response = self.client.post(url, {'command': 'RTL'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(AssetCommand.objects.filter(asset=self.asset, command='RTL').exists())
+
+        AssetCommand.objects.all().delete()
+        rtt.timestamp = timezone.now() - ASSET_CONNECTION_TIMEOUT - timedelta(seconds=5)
+        rtt.save(update_fields=['timestamp'])
+
+        response = self.client.post(url, {'command': 'RTL'})
+
+        self.assertEqual(response.status_code, 409)
+        self.assertFalse(AssetCommand.objects.exists())
+
     @satisfies('TC-WEB-008')
     def test_asset_command_records_issuer(self):
         """The issuing user is recorded on the command and surfaced in the API."""
@@ -226,6 +263,7 @@ class AssetAPITest(TestCase):
         self.client.force_login(self.user)
         token = self._issue_confirmation('TERM')
         other_asset = Asset.objects.create(name='Other Drone')
+        AssetRTT.objects.create(asset=other_asset, rtt=10)
 
         url = reverse('asset_command_set', kwargs={'asset_id': other_asset.pk})
         response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
@@ -383,6 +421,7 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['asset']['name'], 'Test Drone')
+        self.assertTrue(data['connected'])
 
     def test_asset_status_json_command_code(self):
         """Test that asset_status_json includes command_code alongside the display string."""
@@ -496,6 +535,7 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data['asset']['name'], 'Empty Drone')
+        self.assertFalse(data['connected'])
         self.assertNotIn('position', data)
         self.assertNotIn('status', data)
         self.assertNotIn('rtt', data)
@@ -503,6 +543,7 @@ class AssetAPITest(TestCase):
     def test_rtt_sample_limit(self):
         """Test that RTT calculation only uses the latest RTT_SAMPLE_LIMIT samples."""
         self.client.force_login(self.user)
+        AssetRTT.objects.filter(asset=self.asset).delete()
         total_samples = RTT_SAMPLE_LIMIT + 5
         for i in range(1, total_samples + 1):
             AssetRTT.objects.create(asset=self.asset, rtt=i)
@@ -517,6 +558,7 @@ class AssetAPITest(TestCase):
 
     def test_bulk_asset_status_data_ignores_rtts_older_than_scan_window(self):
         """RTTs older than RTT_SCAN_WINDOW are excluded from the aggregation (PERF-02)."""
+        AssetRTT.objects.filter(asset=self.asset).delete()
         now = timezone.now()
         AssetRTT.objects.create(asset=self.asset, rtt=999, timestamp=now - RTT_SCAN_WINDOW - timedelta(minutes=1))
         AssetRTT.objects.create(asset=self.asset, rtt=42, timestamp=now)
@@ -553,6 +595,7 @@ class AssetAPITest(TestCase):
 
     def test_bulk_asset_status_data_per_asset_rtts(self):
         """Each asset gets its own RTT aggregation; assets without RTTs omit the key."""
+        AssetRTT.objects.filter(asset=self.asset).delete()
         now = timezone.now()
         multi = self.asset
         single = Asset.objects.create(name='Single RTT Drone')

--- a/assets/views.py
+++ b/assets/views.py
@@ -20,6 +20,7 @@ from .models import Asset, AssetCommand, AssetCommandConfirmation, AssetPosition
 
 RTT_SAMPLE_LIMIT = 15
 COMMAND_CONFIRMATION_TTL = timedelta(seconds=60)
+ASSET_CONNECTION_TIMEOUT = timedelta(seconds=60)
 
 # How far back the RTT window-function query below looks. Bounds the scan to
 # a fixed recent window instead of the fleet's entire history, while staying
@@ -37,6 +38,29 @@ def server_now_ms():
     browser clock with server/FMU timestamps, which clock skew would corrupt.
     """
     return int(timezone.now().timestamp() * 1000)
+
+
+def asset_has_live_connection(asset, now=None):
+    """
+    Return whether the asset has answered an RTT request recently enough to
+    accept a command.
+
+    RTT responses are the server's direct per-asset liveness signal. The FSS
+    server normally requests one every 10 seconds and times a client out after
+    30 seconds; a 60-second web-side window tolerates scheduling/database
+    jitter while still refusing commands for a connection that is no longer
+    plausibly live.
+    """
+    cutoff = (now or timezone.now()) - ASSET_CONNECTION_TIMEOUT
+    return AssetRTT.objects.filter(asset=asset, timestamp__gte=cutoff).exists()
+
+
+def _latest_rtt_is_recent(rtts, now=None):
+    """Classify an already-fetched, newest-first RTT collection."""
+    if not rtts:
+        return False
+    cutoff = (now or timezone.now()) - ASSET_CONNECTION_TIMEOUT
+    return rtts[0].timestamp >= cutoff
 
 
 @ensure_csrf_cookie
@@ -160,7 +184,7 @@ def _format_command(cmd):
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
-def format_asset_status(asset, position=None, status=None, search=None, rtts=None, command=None):
+def format_asset_status(asset, position=None, status=None, search=None, rtts=None, command=None, now=None):
     """
     Centralized formatting logic for asset status data.
     """
@@ -168,7 +192,11 @@ def format_asset_status(asset, position=None, status=None, search=None, rtts=Non
         'asset': {
             'name': asset.name,
             'pk': asset.pk,
-        }
+        },
+        # This is deliberately based on RTT rather than generic telemetry:
+        # position/status reports may be infrequent while RTT is the FSS
+        # server's active connection heartbeat.
+        'connected': _latest_rtt_is_recent(rtts, now),
     }
 
     pos_data = _format_position(position)
@@ -226,6 +254,7 @@ def asset_status_data(asset):
         search=search,
         rtts=rtts,
         command=command,
+        now=timezone.now(),
     )
 
 
@@ -288,11 +317,12 @@ def bulk_asset_status_data(assets):
     # stays portable across the spatialite (tests) and PostGIS (production)
     # backends.
     rtts_by_asset = {}
+    now = timezone.now()
     asset_ids = [a.pk for a in annotated_assets]
     if asset_ids:
         placeholders = ','.join(['%s'] * len(asset_ids))
         table_name = AssetRTT._meta.db_table
-        scan_cutoff = timezone.now() - RTT_SCAN_WINDOW
+        scan_cutoff = now - RTT_SCAN_WINDOW
         for rtt in AssetRTT.objects.raw(
             "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY asset_id ORDER BY timestamp DESC) AS rn "
             f"FROM {table_name} WHERE asset_id IN ({placeholders}) AND timestamp > %s) t WHERE rn <= %s "
@@ -311,6 +341,7 @@ def bulk_asset_status_data(assets):
                 search=latest['searches'].get(asset.pk),
                 rtts=rtts_by_asset.get(asset.pk, []),
                 command=latest['commands'].get(asset.pk),
+                now=now,
             )
         )
     return results
@@ -376,7 +407,7 @@ def _queue_destructive_command(asset_command, user, confirmation_token):
 
 
 @login_required_api
-def asset_command_set(request, asset_id):
+def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-statements
     """
     Set the command for a given asset
     """
@@ -406,6 +437,11 @@ def asset_command_set(request, asset_id):
                     raise ValueError
             except (ValueError, TypeError):
                 return HttpResponseBadRequest('Invalid Altitude')
+        if not asset_has_live_connection(asset):
+            return HttpResponse(
+                "Asset is disconnected: no recent RTT response",
+                status=409,
+            )
         # @login_required_api guarantees an authenticated user here; guard
         # anyway so that decorator changing can't try to assign an AnonymousUser
         # to the FK. None keeps the command row, just without an attributed user.


### PR DESCRIPTION
## Description

Use recent RTT responses as the server-side asset liveness signal so commands cannot be queued when no connection can deliver them. Expose the same decision in status JSON and add TC-WEB-013 coverage for missing, recent, and stale RTT data.

## Summary by Sourcery

Block asset command submission when the asset has no recent RTT response and surface connection status in asset status JSON.

Enhancements:
- Introduce an RTT-based asset connection timeout and helper logic to classify assets as connected for command eligibility and status formatting.
- Propagate current time into asset status formatting and bulk status aggregation to consistently evaluate recent RTTs within a bounded window.

Tests:
- Extend asset view tests to cover command blocking for assets without RTTs or with stale RTT data, and to assert the new connected flag in asset status JSON including TC-WEB-013 scenarios.
- Adjust existing RTT-related tests to reset RTT data per asset to accurately exercise sample limiting and scan window behavior.