### PR TITLE
feat(frontend): gate commands on live targets

### DIFF
--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -6,15 +6,26 @@ import { AssetStatus } from './server'
 
 const makeServer = (name: string, csrfToken = 'tok', url = `https://${name}.example`): ServerState => ({
   ...createServer(name, '10.0.0.1', 8080, url),
+  connected: true,
+  userName: 'pilot',
   csrfToken
 })
 
-const makeAsset = (name: string, servers: Array<{ serverKey: string; serverName?: string; assetPk: number }>): AssetState => ({
+const makeAsset = (name: string, servers: Array<{ serverKey: string; serverName?: string; assetPk: number; connected?: boolean }>): AssetState => ({
   name,
-  servers: Object.fromEntries(servers.map((s) => [s.serverKey, { serverName: s.serverName ?? s.serverKey, assetPk: s.assetPk }]))
+  servers: Object.fromEntries(
+    servers.map((s) => [
+      s.serverKey,
+      {
+        serverName: s.serverName ?? s.serverKey,
+        assetPk: s.assetPk,
+        data: statusFor(name, s.assetPk, s.connected ?? true)
+      }
+    ])
+  )
 })
 
-const statusFor = (name: string, pk: number): AssetStatus => ({ asset: { name, pk } })
+const statusFor = (name: string, pk: number, connected = true): AssetStatus => ({ asset: { name, pk }, connected })
 
 describe('sendAssetCommand', () => {
   afterEach(() => {
@@ -149,6 +160,35 @@ describe('sendAssetCommand', () => {
 
     await sendAssetCommand(servers, asset, { command: 'RTL' })
 
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://alpha.example/assets/1/command/set/')
+  })
+
+  it('does not submit when no server reports a live asset connection', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1, connected: false }])
+
+    await expect(sendAssetCommand(servers, asset, { command: 'RTL' })).rejects.toThrow(/Drone has no commandable server.*alpha: asset disconnected/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('skips and reports an unauthenticated peer while dispatching to a commandable server', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = {
+      alpha: makeServer('alpha'),
+      beta: { ...makeServer('beta'), userName: undefined, csrfToken: undefined }
+    }
+    const asset = makeAsset('Drone', [
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'beta', assetPk: 2 }
+    ])
+
+    await expect(sendAssetCommand(servers, asset, { command: 'RTL' })).rejects.toThrow(/queued on 1 of 2 server\(s\).*Skipped: beta: login required/s)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0][0]).toBe('https://alpha.example/assets/1/command/set/')
   })

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -33,26 +33,60 @@ export const getAssetServerURL = (server: ServerState, assetServer: AssetServerS
 interface AssetTarget {
   server: ServerState
   assetServer: AssetServerState
+  blockedReason?: string
 }
 
 const isDestructiveCommand = (command: Command): command is DestructiveCommand => command === 'DISARM' || command === 'TERM'
+
+const assetTargetBlockReason = (server: ServerState, assetServer: AssetServerState): string | undefined => {
+  if (!server.connected) return 'management server unreachable'
+  if (!server.userName || !server.csrfToken) return 'login required'
+  if (assetServer.data?.connected !== true) return 'asset disconnected'
+  return undefined
+}
 
 const resolveAssetTargets = (knownServers: Record<string, ServerState>, asset: AssetState): AssetTarget[] => {
   const targetsByOrigin = new Map<string, AssetTarget>()
   for (const [serverKey, assetServer] of Object.entries(asset.servers)) {
     const server = knownServers[serverKey]
     if (!server) continue
-    if (!targetsByOrigin.has(server.url)) {
-      targetsByOrigin.set(server.url, { assetServer, server })
+    const target = { assetServer, server, blockedReason: assetTargetBlockReason(server, assetServer) }
+    const existing = targetsByOrigin.get(server.url)
+    // Prefer a commandable entry when old aliases for the same origin coexist.
+    if (!existing || (existing.blockedReason && !target.blockedReason)) {
+      targetsByOrigin.set(server.url, target)
     }
   }
 
   return Array.from(targetsByOrigin.values())
 }
 
+export interface AssetCommandAvailability {
+  commandable: boolean
+  blockedReasons: string[]
+}
+
+export const assetCommandAvailability = (knownServers: Record<string, ServerState>, asset: AssetState): AssetCommandAvailability => {
+  const targets = resolveAssetTargets(knownServers, asset)
+  const blockedReasons = targets.filter((target) => target.blockedReason).map((target) => `${target.assetServer.serverName}: ${target.blockedReason}`)
+  if (targets.length === 0) {
+    blockedReasons.push('no known management server')
+  }
+  return {
+    commandable: targets.some((target) => !target.blockedReason),
+    blockedReasons
+  }
+}
+
 export const sendAssetCommand = async (knownServers: Record<string, ServerState>, asset: AssetState, data: CommandPayload) => {
   const entries: [string, string][] = Object.entries(data).map(([k, v]) => [k, String(v)])
-  const targets = resolveAssetTargets(knownServers, asset)
+  const resolvedTargets = resolveAssetTargets(knownServers, asset)
+  const targets = resolvedTargets.filter((target) => !target.blockedReason)
+  const skipped = resolvedTargets.filter((target) => target.blockedReason)
+  if (targets.length === 0) {
+    const reasons = skipped.length > 0 ? skipped.map((target) => `${target.assetServer.serverName}: ${target.blockedReason}`).join(', ') : 'no known management server'
+    throw new Error(`Command not sent — ${asset.name} has no commandable server (${reasons})`)
+  }
   const results = await Promise.allSettled(
     targets.map(async ({ assetServer, server }) => {
       const post = (path: string, bodyEntries: [string, string][]) =>
@@ -66,6 +100,7 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
           body: new URLSearchParams(bodyEntries)
         }).then((response) => {
           if (response.status === 403) throw new Error('not authenticated — please refresh and log in')
+          if (response.status === 409) throw new Error('asset disconnected — no recent RTT response')
           if (!response.ok) throw new Error(`${response.status} ${response.statusText}`)
           return response
         })
@@ -85,7 +120,7 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
 
   const failures = results.map((result, i) => ({ result, serverName: targets[i].assetServer.serverName })).filter(({ result }) => result.status === 'rejected')
 
-  if (failures.length > 0) {
+  if (failures.length > 0 || skipped.length > 0) {
     const failureMessages = failures
       .map(({ result, serverName }) => {
         const reason = (result as PromiseRejectedResult).reason
@@ -94,8 +129,10 @@ export const sendAssetCommand = async (knownServers: Record<string, ServerState>
       })
       .join(', ')
     const successCount = targets.length - failures.length
-    const prefix = successCount > 0 ? `Command was queued on ${successCount} of ${targets.length} server(s) — aircraft may already be affected. ` : ''
-    throw new Error(`${prefix}Failed on: ${failureMessages}`)
+    const prefix = successCount > 0 ? `Command was queued on ${successCount} of ${resolvedTargets.length} server(s) — aircraft may already be affected. ` : ''
+    const skippedMessage = skipped.length > 0 ? `Skipped: ${skipped.map((target) => `${target.assetServer.serverName}: ${target.blockedReason}`).join(', ')}. ` : ''
+    const failedMessage = failures.length > 0 ? `Failed on: ${failureMessages}` : ''
+    throw new Error(`${prefix}${skippedMessage}${failedMessage}`.trim())
   }
 }
 

--- a/frontend/destructive-command-controls.tsx
+++ b/frontend/destructive-command-controls.tsx
@@ -12,9 +12,10 @@ interface ModalWithButtonProps {
   body: ReactNode
   footer: (onClose: () => void) => ReactNode
   onShow?: () => void
+  disabled?: boolean
 }
 
-export const ModalWithButton: React.FC<ModalWithButtonProps> = ({ label, variant, title, body, footer, onShow }) => {
+export const ModalWithButton: React.FC<ModalWithButtonProps> = ({ label, variant, title, body, footer, onShow, disabled = false }) => {
   const [isOpen, setIsOpen] = useState(false)
   const handleClose = () => setIsOpen(false)
   const handleShow = () => {
@@ -24,7 +25,7 @@ export const ModalWithButton: React.FC<ModalWithButtonProps> = ({ label, variant
 
   return (
     <>
-      <Button onClick={handleShow} variant={variant}>
+      <Button onClick={handleShow} variant={variant} disabled={disabled}>
         {label}
       </Button>
       <Modal show={isOpen} onHide={handleClose}>
@@ -41,17 +42,19 @@ export const ModalWithButton: React.FC<ModalWithButtonProps> = ({ label, variant
 interface DestructiveCommandProps {
   controller: AssetController
   command: CommandExecutor
+  disabled?: boolean
 }
 
-export const DisArm: React.FC<DestructiveCommandProps> = ({ controller, command }) => (
+export const DisArm: React.FC<DestructiveCommandProps> = ({ controller, command, disabled = false }) => (
   <ModalWithButton
     label="DisArm"
     variant="danger"
     title={<>Disarm {controller.name}</>}
     body={<>Warning this will probably result in the aircraft crashing. Use only when all other options are unsafe.</>}
+    disabled={disabled}
     footer={(onClose) => (
       <>
-        <Button variant="danger" onClick={command(controller.DisArm, onClose)}>
+        <Button variant="danger" onClick={command(controller.DisArm, onClose)} disabled={disabled}>
           DisArm
         </Button>
         <Button variant="primary" onClick={onClose}>
@@ -62,7 +65,7 @@ export const DisArm: React.FC<DestructiveCommandProps> = ({ controller, command 
   />
 )
 
-export const Terminate: React.FC<DestructiveCommandProps> = ({ controller, command }) => (
+export const Terminate: React.FC<DestructiveCommandProps> = ({ controller, command, disabled = false }) => (
   <ModalWithButton
     label="Terminate"
     variant="danger"
@@ -73,15 +76,16 @@ export const Terminate: React.FC<DestructiveCommandProps> = ({ controller, comma
         property. Use RTL or Hold instead.
       </>
     }
+    disabled={disabled}
     footer={(onClose) => (
       <>
-        <Button variant="danger" onClick={command(controller.Terminate, onClose)}>
+        <Button variant="danger" onClick={command(controller.Terminate, onClose)} disabled={disabled}>
           Terminate Flight
         </Button>
-        <Button variant="light" onClick={command(controller.RTL, onClose)}>
+        <Button variant="light" onClick={command(controller.RTL, onClose)} disabled={disabled}>
           RTL
         </Button>
-        <Button variant="light" onClick={command(controller.Hold, onClose)}>
+        <Button variant="light" onClick={command(controller.Hold, onClose)} disabled={disabled}>
           Hold
         </Button>
         <Button variant="primary" onClick={onClose}>

--- a/frontend/fss-main-page.test.tsx
+++ b/frontend/fss-main-page.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { mergeServerAssets } from './asset'
+import { FSSAsset } from './fss-main-page'
+import { AssetStatus, ServerState, createServer } from './server'
+
+const SERVER_KEY = 'https://alpha.example'
+const SERVER_NOW = 1_700_000_000_000
+
+const makeServer = (): ServerState => ({
+  ...createServer('alpha', '10.0.0.1', 8080, SERVER_KEY),
+  connected: true,
+  userName: 'pilot',
+  csrfToken: 'csrf-123'
+})
+
+const cannedAssetStatus = (connected: boolean): AssetStatus => ({
+  asset: { name: 'Drone', pk: 42 },
+  connected
+})
+
+afterEach(cleanup)
+
+describe('disconnected asset command controls', () => {
+  it('disables every command control when canned status reports no live connection', () => {
+    const servers = { [SERVER_KEY]: makeServer() }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [cannedAssetStatus(false)], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    expect(screen.getByRole('status').textContent).toContain('Commands disabled: alpha: asset disconnected')
+    for (const name of ['RTL', 'Hold', 'Altitude', 'Goto', 'Continue', 'Manual', 'DisArm', 'Terminate']) {
+      expect((screen.getByRole('button', { name }) as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  it('keeps command controls enabled when canned status reports a live connection', () => {
+    const servers = { [SERVER_KEY]: makeServer() }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [cannedAssetStatus(true)], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect((screen.getByRole('button', { name: 'RTL' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+})

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -1,5 +1,5 @@
 import { type Axis, degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
-import { AssetState, AssetServerState, AssetController, createAssetController, mergeServerAssets } from './asset'
+import { AssetState, AssetServerState, AssetController, assetCommandAvailability, createAssetController, mergeServerAssets } from './asset'
 import { ServerState, canonicalServerOrigin, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, mergeServerPollResult } from './server'
 import {
   assetPositionTimeWarn,
@@ -59,9 +59,10 @@ const useCommand = () => {
 
 interface AssetProps {
   controller: AssetController
+  disabled?: boolean
 }
 
-const AltitudeSelect: React.FC<AssetProps> = ({ controller }) => {
+const AltitudeSelect: React.FC<AssetProps> = ({ controller, disabled = false }) => {
   const [newAltitude, setNewAltitude] = useState(100)
   const command = useCommand()
 
@@ -69,6 +70,7 @@ const AltitudeSelect: React.FC<AssetProps> = ({ controller }) => {
     <ModalWithButton
       label="Altitude"
       variant="outline-secondary"
+      disabled={disabled}
       title="Set Target Altitude:"
       body={
         <>
@@ -78,7 +80,7 @@ const AltitudeSelect: React.FC<AssetProps> = ({ controller }) => {
       }
       footer={(onClose) => (
         <>
-          <Button variant="light" onClick={command(() => controller.Altitude(newAltitude), onClose)}>
+          <Button variant="light" onClick={command(() => controller.Altitude(newAltitude), onClose)} disabled={disabled}>
             Set Altitude
           </Button>
           <Button variant="primary" onClick={onClose}>
@@ -92,7 +94,7 @@ const AltitudeSelect: React.FC<AssetProps> = ({ controller }) => {
 
 const getDefaultPosition = (): AssetPositionData => ({ timestamp: '', lat: 0, lng: 0 })
 
-const Goto: React.FC<AssetProps> = ({ controller }) => {
+const Goto: React.FC<AssetProps> = ({ controller, disabled = false }) => {
   const [position, setPosition] = useState<AssetPositionData | undefined>(undefined)
   const command = useCommand()
 
@@ -126,6 +128,7 @@ const Goto: React.FC<AssetProps> = ({ controller }) => {
     <ModalWithButton
       label="Goto"
       variant="outline-secondary"
+      disabled={disabled}
       onShow={onShow}
       title={<>Send {controller.name} to:</>}
       body={
@@ -143,7 +146,7 @@ const Goto: React.FC<AssetProps> = ({ controller }) => {
       }
       footer={(onClose) => (
         <>
-          <Button variant="light" onClick={handleGoto(onClose)} disabled={!position}>
+          <Button variant="light" onClick={handleGoto(onClose)} disabled={disabled || !position}>
             Goto
           </Button>
           <Button variant="primary" onClick={onClose}>
@@ -155,27 +158,27 @@ const Goto: React.FC<AssetProps> = ({ controller }) => {
   )
 }
 
-const FSSAssetControls: React.FC<AssetProps> = ({ controller }) => {
+export const FSSAssetControls: React.FC<AssetProps> = ({ controller, disabled = false }) => {
   const command = useCommand()
 
   return (
     <div className="asset-buttons btn-group" role="group">
-      <button className="btn btn-outline-secondary" onClick={command(controller.RTL)}>
+      <button className="btn btn-outline-secondary" onClick={command(controller.RTL)} disabled={disabled}>
         RTL
       </button>
-      <button className="btn btn-outline-secondary" onClick={command(controller.Hold)}>
+      <button className="btn btn-outline-secondary" onClick={command(controller.Hold)} disabled={disabled}>
         Hold
       </button>
-      <AltitudeSelect controller={controller} />
-      <Goto controller={controller} />
-      <button className="btn btn-outline-secondary" onClick={command(controller.Continue)}>
+      <AltitudeSelect controller={controller} disabled={disabled} />
+      <Goto controller={controller} disabled={disabled} />
+      <button className="btn btn-outline-secondary" onClick={command(controller.Continue)} disabled={disabled}>
         Continue
       </button>
-      <button className="btn btn-info" onClick={command(controller.Manual)}>
+      <button className="btn btn-info" onClick={command(controller.Manual)} disabled={disabled}>
         Manual
       </button>
-      <DisArm controller={controller} command={command} />
-      <Terminate controller={controller} command={command} />
+      <DisArm controller={controller} command={command} disabled={disabled} />
+      <Terminate controller={controller} command={command} disabled={disabled} />
     </div>
   )
 }
@@ -385,13 +388,19 @@ interface FSSAssetContainerProps {
   setSelected: (asset: string, server: string) => void
 }
 
-function FSSAsset(props: FSSAssetContainerProps) {
+export function FSSAsset(props: FSSAssetContainerProps) {
   const { asset, knownServers, setSelected } = props
   const controller = useMemo(() => createAssetController(knownServers, asset), [knownServers, asset])
+  const commandAvailability = useMemo(() => assetCommandAvailability(knownServers, asset), [knownServers, asset])
   return (
     <div className="asset">
       <div className="asset-label">{asset.name}</div>
-      <FSSAssetControls controller={controller} />
+      {!commandAvailability.commandable && (
+        <div className="alert alert-warning asset-command-disabled" role="status">
+          <strong>Commands disabled:</strong> {commandAvailability.blockedReasons.join(', ')}
+        </div>
+      )}
+      <FSSAssetControls controller={controller} disabled={!commandAvailability.commandable} />
       <FSSAssetStatus asset={asset} setSelected={setSelected} />
     </div>
   )

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -56,6 +56,10 @@ export interface AssetStatus {
     name: string
     pk: number
   }
+  // Server-side command-liveness decision, based on the most recent RTT.
+  // Optional only for compatibility with status cached from an older peer;
+  // command submission treats a missing value as disconnected.
+  connected?: boolean
   position?: AssetPositionData
   status?: AssetStatusData
   search?: AssetSearchData


### PR DESCRIPTION
## Description

Disable asset command controls when no reachable authenticated server reports recent RTT liveness. Skip unavailable peers during dispatch and report partial targeting so unauthenticated servers no longer receive guaranteed-failing requests.

## Summary by Sourcery

Gate asset command controls on live, authenticated management servers and improve feedback when commands cannot be dispatched.

New Features:
- Disable asset command UI controls when no server reports a live asset connection and show a warning explaining why commands are unavailable.
- Compute asset command availability based on server connectivity, authentication, and asset liveness, and use it to gate command dispatch.

Bug Fixes:
- Avoid sending asset commands to unauthenticated or unreachable servers and report them as skipped instead of hard failures.
- Treat missing or stale asset liveness data as disconnected to prevent guaranteed-failing command submissions.

Enhancements:
- Aggregate and surface detailed reasons for partial command dispatch, including skipped and failed servers, in error messages.
- Extend command modals and controls to support a disabled state that consistently prevents issuing commands when gating conditions are not met.

Tests:
- Add unit tests for asset command dispatch behavior with disconnected and unauthenticated servers.
- Add UI tests verifying that asset command controls are disabled and a status message is shown when no live asset connection is reported.