### PR TITLE
fix(commands): reject unexpected parameters

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -116,6 +116,18 @@ class AssetCommand(models.Model):
     ALTITUDE_MAX_FT = 999
     altitude = models.IntegerField(null=True, blank=True)
 
+    @classmethod
+    def allowed_parameter_names(cls, command):
+        """Return the complete POST parameter contract for a command."""
+        parameter_names = {'command'}
+        if command in cls.REQUIRES_POSITION:
+            parameter_names.update(('latitude', 'longitude'))
+        if command in cls.REQUIRES_ALTITUDE:
+            parameter_names.add('altitude')
+        if command in cls.DESTRUCTIVE_COMMANDS:
+            parameter_names.add('confirmation_token')
+        return parameter_names
+
     # Who dispatched this command, recorded for the audit trail of a
     # safety-critical action (a TERM/DISARM can destroy the aircraft). NULL when
     # the row was not created by an authenticated web user (e.g. rows predating

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -344,6 +344,37 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content.decode(), 'Invalid command')
 
+    def test_asset_command_set_rejects_unexpected_parameters(self):
+        """Parameters outside each command's contract are rejected, not ignored."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        cases = (
+            ({'command': 'RTL', 'latitude': -43.0, 'longitude': 172.0},
+             'Unexpected parameter(s): latitude, longitude'),
+            ({'command': 'GOTO', 'latitude': -43.0, 'longitude': 172.0, 'altitude': 100},
+             'Unexpected parameter(s): altitude'),
+            ({'command': 'ALT', 'altitude': 100, 'latitude': -43.0},
+             'Unexpected parameter(s): latitude'),
+        )
+
+        for payload, expected_error in cases:
+            with self.subTest(command=payload['command']):
+                response = self.client.post(url, payload)
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.content.decode(), expected_error)
+                self.assertFalse(AssetCommand.objects.exists())
+
+        token = self._issue_confirmation('TERM')
+        response = self.client.post(url, {
+            'command': 'TERM',
+            'confirmation_token': token,
+            'altitude': 100,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content.decode(), 'Unexpected parameter(s): altitude')
+        self.assertFalse(AssetCommand.objects.exists())
+        self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
+
     @satisfies('TC-WEB-012')
     def test_asset_command_set_invalid_altitude(self):
         """Test setting an invalid altitude."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -406,6 +406,16 @@ def _queue_destructive_command(asset_command, user, confirmation_token):
     return True
 
 
+def _command_parameter_error(parameters, command):
+    """Return the first command payload-contract error, if any."""
+    if command not in dict(AssetCommand.COMMAND_CHOICES):
+        return 'Invalid command'
+    unexpected_parameters = set(parameters) - AssetCommand.allowed_parameter_names(command)
+    if unexpected_parameters:
+        return f"Unexpected parameter(s): {', '.join(sorted(unexpected_parameters))}"
+    return None
+
+
 @login_required_api
 def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-statements
     """
@@ -416,9 +426,9 @@ def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-sta
         point = None
         altitude = None
         command = request.POST.get('command')
-        valid_commands = dict(AssetCommand.COMMAND_CHOICES)
-        if command not in valid_commands:
-            return HttpResponseBadRequest('Invalid command')
+        parameter_error = _command_parameter_error(request.POST, command)
+        if parameter_error is not None:
+            return HttpResponseBadRequest(parameter_error)
         if command in AssetCommand.REQUIRES_POSITION:
             latitude = request.POST.get('latitude')
             longitude = request.POST.get('longitude')


### PR DESCRIPTION
## Description

Define each command's accepted POST fields from the existing command classifications so malformed safety-critical requests cannot be accepted after silently dropping stray data. Cover routine, positional, altitude, and destructive payloads, including confirmation-token preservation on rejection.

## Summary by Sourcery

Enforce strict validation of asset command POST payloads so that only parameters allowed by each command type are accepted.

Bug Fixes:
- Reject asset command requests containing unexpected parameters instead of silently ignoring them, including for destructive commands while preserving confirmation tokens.

Enhancements:
- Centralize command parameter validation logic in a helper and a model-level parameter contract helper for reuse and clarity.

Tests:
- Add tests verifying that unexpected parameters for various asset commands are rejected with clear error messages and that no commands are queued.