### PR TITLE
chore(api): remove unused status endpoints

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -37,6 +37,12 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         return response.json()['confirmation_token']
 
+    def _get_asset_status(self, asset=None):
+        target_asset = asset or self.asset
+        response = self.client.get(reverse('all_status_data'))
+        self.assertEqual(response.status_code, 200)
+        return next(data for data in response.json()['assets'] if data['asset']['pk'] == target_asset.pk)
+
     def test_asset_command_set_unauthenticated(self):
         """Test that unauthenticated command attempts are rejected."""
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
@@ -67,7 +73,7 @@ class AssetAPITest(TestCase):
             expire_date=previous_expiry,
         )
 
-        status_url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
+        status_url = reverse('all_status_data')
         activity_time = timezone.now()
         response = self.client.get(status_url)
 
@@ -186,8 +192,7 @@ class AssetAPITest(TestCase):
         cmd = AssetCommand.objects.filter(asset=self.asset).latest('timestamp')
         self.assertEqual(cmd.issued_by, self.user)
 
-        status_url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        data = self.client.get(status_url).json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['issued_by'], 'testuser')
 
     @satisfies('TC-WEB-010')
@@ -438,41 +443,28 @@ class AssetAPITest(TestCase):
         response = self.client.post(url, {'command': 'ALT'})
         self.assertEqual(response.status_code, 400)
 
-    def test_asset_status_json_unauthenticated(self):
-        """Test asset_status_json rejects unauthenticated requests."""
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 403)
-
-    def test_asset_status_json_success(self):
-        """Test asset_status_json for a valid asset."""
+    def test_all_status_data_includes_asset(self):
+        """The bulk status endpoint includes the requested asset's status."""
         self.client.force_login(self.user)
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['asset']['name'], 'Test Drone')
         self.assertTrue(data['connected'])
 
-    def test_asset_status_json_command_code(self):
-        """Test that asset_status_json includes command_code alongside the display string."""
+    def test_all_status_data_command_code(self):
+        """The bulk status endpoint includes command_code alongside the display string."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(asset=self.asset, command='RTL')
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['command_code'], 'RTL')
         self.assertEqual(data['command']['command'], 'Return to Launch')
 
-    def test_asset_status_json_formatted_details(self):
+    def test_all_status_data_formatted_details(self):
         """The response carries formatted position, battery and search data."""
         self.client.force_login(self.user)
         AssetPosition.objects.create(asset=self.asset, position=Point(172.0, -43.0), altitude=120)
         AssetStatus.objects.create(asset=self.asset, bat_percent=85, bat_used_mah=500, bat_volt=11.1)
         AssetSearchProgress.objects.create(asset=self.asset, search=7, search_progress=3, search_progress_of=10)
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
 
         self.assertEqual(data['position']['lat'], -43.0)
         self.assertEqual(data['position']['lng'], 172.0)
@@ -486,31 +478,27 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['search']['progress'], 3)
         self.assertEqual(data['search']['total'], 10)
 
-    def test_asset_status_json_ack_pending(self):
+    def test_all_status_data_ack_pending(self):
         """A dispatched-but-unacked command reports ack_state 'pending'."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(asset=self.asset, command='RTL')
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['ack_state'], 'pending')
         self.assertNotIn('ack_timestamp', data['command'])
 
-    def test_asset_status_json_ack_actioned(self):
+    def test_all_status_data_ack_actioned(self):
         """An actioned ack is surfaced with its code, label and timestamp."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(
             asset=self.asset, command='RTL',
             ack_state=AssetCommand.ACK_ACTIONED, ack_timestamp=1700000000000,
         )
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['ack_state'], 'actioned')
         self.assertEqual(data['command']['ack_state_display'], 'Actioned')
         self.assertEqual(data['command']['ack_timestamp'], 1700000000000)
 
-    def test_asset_status_json_ack_superseded(self):
+    def test_all_status_data_ack_superseded(self):
         """A superseded ack carries the supersede reason as a code string."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(
@@ -518,13 +506,11 @@ class AssetAPITest(TestCase):
             ack_state=AssetCommand.ACK_SUPERSEDED,
             ack_superseded_by=AssetCommand.SUPERSEDE_LOW_BATTERY,
         )
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['ack_state'], 'superseded')
         self.assertEqual(data['command']['ack_superseded_by'], 'low_battery')
 
-    def test_asset_status_json_ack_superseded_newer_command(self):
+    def test_all_status_data_ack_superseded_newer_command(self):
         """A command superseded by a newer command reports that reason code."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(
@@ -532,39 +518,25 @@ class AssetAPITest(TestCase):
             ack_state=AssetCommand.ACK_SUPERSEDED,
             ack_superseded_by=AssetCommand.SUPERSEDE_NEWER_COMMAND,
         )
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['ack_state'], 'superseded')
         self.assertEqual(data['command']['ack_superseded_by'], 'newer_command')
 
-    def test_asset_status_json_ack_noop(self):
+    def test_all_status_data_ack_noop(self):
         """A noop ack (already-current state) reports ack_state 'noop'."""
         self.client.force_login(self.user)
         AssetCommand.objects.create(
             asset=self.asset, command='RTL', ack_state=AssetCommand.ACK_NOOP,
         )
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
         self.assertEqual(data['command']['ack_state'], 'noop')
         self.assertEqual(data['command']['ack_state_display'], 'No change')
-
-    def test_asset_status_json_not_found(self):
-        """Test asset_status_json for a non-existent asset."""
-        self.client.force_login(self.user)
-        url = reverse('asset_status_json', kwargs={'asset_id': 99999})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
 
     def test_asset_status_no_data(self):
         """Test an asset with no status/position/rtt data."""
         self.client.force_login(self.user)
         asset = Asset.objects.create(name='Empty Drone')
-        url = reverse('asset_status_json', kwargs={'asset_id': asset.pk})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = self._get_asset_status(asset)
         self.assertEqual(data['asset']['name'], 'Empty Drone')
         self.assertFalse(data['connected'])
         self.assertNotIn('position', data)
@@ -579,9 +551,7 @@ class AssetAPITest(TestCase):
         for i in range(1, total_samples + 1):
             AssetRTT.objects.create(asset=self.asset, rtt=i)
 
-        url = reverse('asset_status_json', kwargs={'asset_id': self.asset.pk})
-        response = self.client.get(url)
-        data = response.json()
+        data = self._get_asset_status()
 
         rtt_data = data['rtt']
         self.assertEqual(rtt_data['rtt_max'], total_samples)

--- a/assets/urls.py
+++ b/assets/urls.py
@@ -9,7 +9,6 @@ from . import views
 urlpatterns = [
     re_path(r'^$', views.assets_main, name='assets_main'),
     re_path(r'^add/$', views.asset_add, name='asset_add'),
-    re_path(r'^(?P<asset_id>\d+)/status.json$', views.asset_status_json, name='asset_status_json'),
     re_path(r'^(?P<asset_id>\d+)/command/confirm/$', views.asset_command_confirm, name='asset_command_confirm'),
     re_path(r'^(?P<asset_id>\d+)/command/set/$', views.asset_command_set, name='asset_command_set'),
 ]

--- a/assets/views.py
+++ b/assets/views.py
@@ -2,11 +2,10 @@
 Views for Assets
 """
 
-import contextlib
 from datetime import timedelta
 
 from django.contrib.gis.geos import Point
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import OuterRef, Subquery
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
@@ -222,42 +221,6 @@ def format_asset_status(asset, position=None, status=None, search=None, rtts=Non
     return data
 
 
-def asset_status_data(asset):
-    """
-    Get all the current status data for an asset (single-asset, DB-backed).
-    """
-    position = status = search = command = None
-    rtts = []
-
-    with contextlib.suppress(ObjectDoesNotExist):
-        position = AssetPosition.objects.filter(asset=asset).latest('timestamp')
-
-    with contextlib.suppress(ObjectDoesNotExist):
-        status = AssetStatus.objects.filter(asset=asset).latest('timestamp')
-
-    with contextlib.suppress(ObjectDoesNotExist):
-        search = AssetSearchProgress.objects.filter(asset=asset).latest('timestamp')
-
-    with contextlib.suppress(IndexError):
-        rtts = list(
-            AssetRTT.objects.filter(asset=asset)
-            .order_by('-timestamp')[:RTT_SAMPLE_LIMIT]
-        )
-
-    with contextlib.suppress(ObjectDoesNotExist):
-        command = AssetCommand.objects.filter(asset=asset).select_related('issued_by').latest('timestamp')
-
-    return format_asset_status(
-        asset,
-        position=position,
-        status=status,
-        search=search,
-        rtts=rtts,
-        command=command,
-        now=timezone.now(),
-    )
-
-
 def bulk_asset_status_data(assets):
     """
     Get current status data for a list of assets efficiently.
@@ -345,16 +308,6 @@ def bulk_asset_status_data(assets):
             )
         )
     return results
-
-
-@login_required_api
-def asset_status_json(request, asset_id):
-    """
-    Show the current asset status
-    """
-    asset = get_object_or_404(Asset, pk=asset_id)
-
-    return JsonResponse(asset_status_data(asset))
 
 
 @login_required_api

--- a/main/tests/test_unauth_sweep.py
+++ b/main/tests/test_unauth_sweep.py
@@ -13,16 +13,12 @@ from assets.models import Asset, AssetCommand
 from fss.satisfies import satisfies
 
 # Endpoints deliberately reachable without authentication: the SPA shell (its
-# auth-gated data is fetched separately via JS), the login flow itself, and
-# current_user - a deliberate auth probe returning null when logged out (see
-# chore-02-remove-unused-api-endpoints.md, which flags it as unused/worth
-# reviewing on its own merits - that's a separate decision from this sweep).
+# auth-gated data is fetched separately via JS) and the login flow itself.
 PUBLIC_URL_NAMES = {
     'main_view',
     'assets_main',
     'config_main',
     'login_page',
-    'current_user',
 }
 
 # django.contrib.admin and django.contrib.auth's own URLs (password reset

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -116,36 +116,13 @@ class StatusAPITest(TestCase):
 
         self.assertIsNone(data['assets'][0]['status']['battery_voltage'])
 
-    def test_current_user_unauthenticated(self):
-        """Test current_user when not logged in."""
-        url = reverse('current_user')
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNone(response.json()['currentUser'])
-
-    def test_current_user_authenticated(self):
-        """Test current_user when logged in."""
+    def test_legacy_api_endpoints_are_removed(self):
+        """Legacy endpoints stay outside the authenticated API surface."""
         self.client.login(username='testuser', password='password')
-        url = reverse('current_user')
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()['currentUser'], 'testuser')
-
-    def test_server_list_unauthenticated(self):
-        """Test server_list rejects unauthenticated requests."""
-        url = reverse('server_list')
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 403)
-
-    def test_server_list_authenticated(self):
-        """Test server_list returns data when logged in."""
-        self.client.login(username='testuser', password='password')
-        url = reverse('server_list')
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(len(data['servers']), 1)
-        self.assertEqual(data['servers'][0]['name'], 'Test Server')
+        for path in ('/servers.json', '/current_user/', f'/assets/{self.asset.pk}/status.json'):
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 404)
 
     def test_asset_list_unauthenticated(self):
         """Test asset_list rejects unauthenticated requests."""

--- a/main/urls.py
+++ b/main/urls.py
@@ -7,10 +7,8 @@ from django.urls import re_path
 from . import views
 
 urlpatterns = [
-    re_path(r'^servers.json$', views.server_list, name='server_list'),
     re_path(r'^assets.json$', views.asset_list, name='asset_list'),
     re_path(r'^$', views.main_view, name='main_view'),
     re_path(r'^current/all.json/$', views.all_status_data, name='all_status_data'),
-    re_path(r'^current_user/$', views.current_user, name='current_user'),
     re_path(r'^login/$', views.login_page, name='login_page'),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -22,25 +22,6 @@ def main_view(request):
 
 
 @login_required_api
-def server_list(request):
-    """
-    Return the active servers as a json array
-    """
-    servers = ServerConfig.objects.filter(active=True)
-    servers_list = []
-    for server in servers:
-        server_details = {
-            'name': server.name,
-            'address': server.address,
-            'client_port': server.client_port,
-            'url': server.http_address(),
-        }
-        servers_list.append(server_details)
-
-    return JsonResponse({'servers': servers_list})
-
-
-@login_required_api
 def asset_list(request):
     """
     Return the know assets as a json array
@@ -57,14 +38,6 @@ def asset_list(request):
             'smm_login': config.smm_login if config else None,
         })
     return JsonResponse({'assets': assets_list})
-
-
-def current_user(request):
-    """
-    Return the current user, helps determine if the client is logged in
-    """
-    user = request.user.username if request.user.is_authenticated else None
-    return JsonResponse({'currentUser': user})
 
 
 @ensure_csrf_cookie


### PR DESCRIPTION
## Description

The SPA and adjacent FSS/SMM services use the consolidated status API, leaving three legacy JSON routes as unsupported attack surface. Remove those routes and keep their payload coverage on the bulk endpoint.

## Summary by Sourcery

Remove legacy per-asset and user/server status JSON endpoints in favor of the consolidated bulk status API and tighten unauthenticated surface area.

Bug Fixes:
- Ensure status-related tests exercise the consolidated all_status_data endpoint rather than removed per-asset status routes.

Enhancements:
- Add helper utilities and tests to validate asset status data via the bulk status endpoint, preserving previous payload expectations.
- Add regression coverage to assert that legacy JSON API paths remain unreachable (404) even for authenticated users.

Tests:
- Update and consolidate asset status view tests to rely on the bulk status endpoint while maintaining coverage of command, RTT, and search metadata.