### PR TITLE
feat(frontend): warn when FSS redundancy is lost

### DIFF
--- a/frontend/fss-main-page.test.tsx
+++ b/frontend/fss-main-page.test.tsx
@@ -5,14 +5,14 @@ import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { mergeServerAssets } from './asset'
-import { FSSAsset } from './fss-main-page'
-import { AssetStatus, ServerState, createServer } from './server'
+import { FSSAsset, FSSServerBar } from './fss-main-page'
+import { AssetStatus, ServerState, createServer, serverConnectFailed } from './server'
 
 const SERVER_KEY = 'https://alpha.example'
 const SERVER_NOW = 1_700_000_000_000
 
-const makeServer = (): ServerState => ({
-  ...createServer('alpha', '10.0.0.1', 8080, SERVER_KEY),
+const makeServer = (name = 'alpha'): ServerState => ({
+  ...createServer(name, `10.0.0.${name === 'alpha' ? '1' : '2'}`, 8080, `https://${name}.example`),
   connected: true,
   userName: 'pilot',
   csrfToken: 'csrf-123'
@@ -46,5 +46,36 @@ describe('disconnected asset command controls', () => {
 
     expect(screen.queryByRole('status')).toBeNull()
     expect((screen.getByRole('button', { name: 'RTL' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+})
+
+describe('FSS server redundancy status', () => {
+  it('reports nominal status when at least two FSS servers are reachable', () => {
+    render(<FSSServerBar knownServers={[makeServer('alpha'), makeServer('beta')]} />)
+
+    expect(screen.getByRole('status').textContent).toBe('Systems: Nominal — 2 FSS servers reachable')
+  })
+
+  // satisfies: TC-WEB-015
+  it('reports critical status and identifies an unreachable server when redundancy is lost', () => {
+    const offline = serverConnectFailed(makeServer('beta'))
+
+    render(<FSSServerBar knownServers={[makeServer('alpha'), offline]} />)
+
+    expect(screen.getByRole('status').textContent).toBe('Systems: Critical — Redundancy lost: 1 FSS server reachable; 2 required')
+    expect(screen.getByText('beta').classList.contains('server-label-failure')).toBe(true)
+    expect(screen.getByText('Unreachable')).toBeTruthy()
+  })
+
+  it('reports critical status when only one server is configured and reachable', () => {
+    render(<FSSServerBar knownServers={[makeServer('alpha')]} />)
+
+    expect(screen.getByRole('status').textContent).toContain('Systems: Critical')
+  })
+
+  it('reports critical status when no servers are reachable', () => {
+    render(<FSSServerBar knownServers={[serverConnectFailed(makeServer('alpha')), serverConnectFailed(makeServer('beta'))]} />)
+
+    expect(screen.getByRole('status').textContent).toBe('Systems: Critical — Redundancy lost: 0 FSS servers reachable; 2 required')
   })
 })

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -448,10 +448,18 @@ interface FSSServerBarProps {
   knownServers: ServerState[]
 }
 
-function FSSServerBar(props: FSSServerBarProps) {
+export function FSSServerBar(props: FSSServerBarProps) {
   const { knownServers } = props
+  const reachableServers = knownServers.filter((server) => server.connected).length
+  const redundancyLost = reachableServers < 2
+  const serverNoun = reachableServers === 1 ? 'server' : 'servers'
   return (
     <div className="bar-server">
+      <div className={`alert ${redundancyLost ? 'alert-danger' : 'alert-success'} system-status`} role="status">
+        <strong>Systems: {redundancyLost ? 'Critical' : 'Nominal'}</strong>
+        {' — '}
+        {redundancyLost ? `Redundancy lost: ${reachableServers} FSS ${serverNoun} reachable; 2 required` : `${reachableServers} FSS ${serverNoun} reachable`}
+      </div>
       {knownServers.map((server) => (
         <FSSServer key={server.url} server={server} />
       ))}

--- a/frontend/fssweb.css
+++ b/frontend/fssweb.css
@@ -8,6 +8,10 @@ div.bar-server {
   text-align: center;
 }
 
+.system-status {
+  margin: 0 10px 10px;
+}
+
 div.bar-assets {
   width: 100%;
   margin: 0 auto;


### PR DESCRIPTION
## Description

Operators need a global safety signal when fewer than two management servers remain reachable; individual red server cards alone do not make the loss of required redundancy explicit. Add nominal and critical system states and cover the degraded rendering required by TC-WEB-015.

## Summary by Sourcery

Add a global FSS server redundancy status indicator to the main page and surface critical system state when required redundancy is lost.

New Features:
- Display a system status banner indicating nominal or critical FSS server redundancy based on reachable management servers.

Enhancements:
- Style the system status banner in the server bar for clear visual prominence.
- Export the FSSServerBar component and cover redundancy status behaviour with new frontend tests.

Tests:
- Add tests to verify nominal and critical redundancy status messaging, including unreachable server labelling and single/no-server scenarios.