### PR TITLE
feat(db): notify FSS of inserted commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Performance / Operations
 
+- **Push-ready command dispatch** — PostgreSQL now publishes committed command inserts on the `fss_command` channel with the asset ID as payload, enabling the FSS server to replace its bounded command poll with `LISTEN`/`NOTIFY` when its listener is implemented. Dispatch and acknowledgement updates do not notify.
 - **Aligned telemetry retention** — operators can opt position, status, RTT, and search-progress tables into independent age limits while preserving a shared recent per-asset timeline (24 hours by default). The management command supports dry runs and batched deletion, with opt-in daily Compose and systemd automation; command and audit records remain untouched.
 - **Executable Docker access modes** — local HTTP evaluation now requires explicit insecure-cookie overrides and remains bound to loopback, while an optional nginx Compose proxy provides the production HTTPS path with operator-managed certificates.
 

--- a/assets/migrations/0012_assetcommand_notify.py
+++ b/assets/migrations/0012_assetcommand_notify.py
@@ -1,0 +1,56 @@
+from django.db import migrations
+
+CREATE_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION fss_notify_assetcommand() RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('fss_command', NEW.asset_id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+CREATE_TRIGGER_SQL = """
+CREATE TRIGGER fss_assetcommand_notify
+    AFTER INSERT ON assets_assetcommand
+    FOR EACH ROW EXECUTE FUNCTION fss_notify_assetcommand();
+"""
+
+DROP_TRIGGER_SQL = """
+DROP TRIGGER fss_assetcommand_notify ON assets_assetcommand;
+"""
+
+DROP_FUNCTION_SQL = """
+DROP FUNCTION fss_notify_assetcommand();
+"""
+
+
+def create_assetcommand_notify(_apps, schema_editor):
+    """Install the command notification trigger on production PostgreSQL."""
+    if schema_editor.connection.vendor != "postgresql":
+        return
+
+    schema_editor.execute(CREATE_FUNCTION_SQL)
+    schema_editor.execute(CREATE_TRIGGER_SQL)
+
+
+def drop_assetcommand_notify(_apps, schema_editor):
+    """Remove the command notification trigger from PostgreSQL."""
+    if schema_editor.connection.vendor != "postgresql":
+        return
+
+    schema_editor.execute(DROP_TRIGGER_SQL)
+    schema_editor.execute(DROP_FUNCTION_SQL)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("assets", "0011_assetcommandconfirmation"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_assetcommand_notify,
+            drop_assetcommand_notify,
+        ),
+    ]

--- a/assets/tests/test_command_notify.py
+++ b/assets/tests/test_command_notify.py
@@ -1,0 +1,57 @@
+"""
+PostgreSQL integration coverage for asset-command insertion notifications.
+"""
+
+from unittest import skipUnless
+
+import psycopg
+from django.db import connection
+from django.test import TransactionTestCase
+
+from assets.models import Asset, AssetCommand
+
+
+@skipUnless(connection.vendor == "postgresql", "PostgreSQL-specific integration test")
+class AssetCommandNotifyTest(TransactionTestCase):
+    """The database wakes the FSS server only for newly queued commands."""
+
+    def test_insert_notifies_asset_id_and_update_does_not(self):
+        """INSERT publishes the asset id; server-owned UPDATE fields stay quiet."""
+        asset = Asset.objects.create(name="Notify Test Asset")
+
+        with psycopg.connect(
+            **connection.get_connection_params(),
+            autocommit=True,
+        ) as listener:
+            listener.execute("LISTEN fss_command")
+
+            command = AssetCommand.objects.create(asset=asset, command="RTL")
+            notifications = list(listener.notifies(timeout=1, stop_after=1))
+
+            self.assertEqual(len(notifications), 1)
+            self.assertEqual(notifications[0].channel, "fss_command")
+            self.assertEqual(notifications[0].payload, str(asset.pk))
+
+            AssetCommand.objects.filter(pk=command.pk).update(dispatch_id=1)
+            self.assertEqual(
+                list(listener.notifies(timeout=0.1, stop_after=1)),
+                [],
+            )
+
+    def test_trigger_is_after_insert_for_each_row(self):
+        """Catalog metadata pins the trigger to AFTER INSERT for each row."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT pg_trigger.tgtype
+                FROM pg_trigger
+                JOIN pg_class ON pg_class.oid = pg_trigger.tgrelid
+                WHERE pg_trigger.tgname = 'fss_assetcommand_notify'
+                  AND pg_class.relname = 'assets_assetcommand'
+                  AND NOT pg_trigger.tgisinternal
+                """
+            )
+            trigger_types = cursor.fetchall()
+
+        # PostgreSQL tgtype bits: ROW (1) | INSERT (4), with BEFORE unset.
+        self.assertEqual(trigger_types, [(5,)])


### PR DESCRIPTION
## Description

The FSS listener needs a transaction-bound wake-up for every command writer. Add a PostgreSQL AFTER INSERT trigger with the agreed asset-id payload while preserving SpatiaLite tests, and cover both delivery and the insert-only constraint against PostGIS.

## Summary by Sourcery

Add PostgreSQL-backed notifications for newly inserted asset commands so the FSS server can react to queued commands without polling, while keeping behavior unchanged for non-PostgreSQL databases.

New Features:
- Publish asset-command inserts on the PostgreSQL `fss_command` channel with the asset ID as payload to support FSS listener wake-ups.

Enhancements:
- Introduce a Django migration that installs and removes a PostgreSQL trigger and function for asset-command notifications, gated by database vendor.
- Document the new push-ready command dispatch behavior in the changelog under performance and operations.

Tests:
- Add PostgreSQL integration tests verifying asset-command insert notifications, absence of notifications on updates, and correct AFTER INSERT row-level trigger configuration.