### PR TITLE
test(compose): cover fresh database startup

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -134,3 +134,10 @@ jobs:
         run: |
           source venv/bin/activate
           ./manage.py test --settings=fss.test_settings_postgis
+
+  compose-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test a fresh Docker Compose deployment
+        run: ./test-docker-compose.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Push-ready command dispatch** — PostgreSQL now publishes committed command inserts on the `fss_command` channel with the asset ID as payload, enabling the FSS server to replace its bounded command poll with `LISTEN`/`NOTIFY` when its listener is implemented. Dispatch and acknowledgement updates do not notify.
 - **Aligned telemetry retention** — operators can opt position, status, RTT, and search-progress tables into independent age limits while preserving a shared recent per-asset timeline (24 hours by default). The management command supports dry runs and batched deletion, with opt-in daily Compose and systemd automation; command and audit records remain untouched.
 - **Executable Docker access modes** — local HTTP evaluation now requires explicit insecure-cookie overrides and remains bound to loopback, while an optional nginx Compose proxy provides the production HTTPS path with operator-managed certificates.
+- **Fresh-database Compose startup** — PostgreSQL now provisions the configured `DB_NAME`, readiness checks that exact database, and Compose rejects missing database credentials before startup. CI verifies migrations and an authenticated request against a fresh isolated volume with deliberately different database and user names.
 
 ## 1.0.0 — 2026-05-17
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,22 @@ command dispatch — not just polling — work between peers.
    CORS_ALLOWED_ORIGINS=https://fss2.example.com,https://fss3.example.com
    ```
 
+### Verify a fresh Docker deployment
+
+Run the Compose smoke test after changing the image, entrypoint, database
+settings, or migrations:
+
+```bash
+./test-docker-compose.sh
+```
+
+The test renders the documented environment shape, checks that missing
+database settings fail interpolation, and starts an isolated Compose project
+with different database and user names. It then proves the web container
+completes migrations and serves an authenticated request. The temporary
+containers, network, and fresh database volume are removed when the test
+finishes; an existing Compose project is not used.
+
 ---
 
 ## Installing into a venv (for direct install / systemd service)

--- a/docker/compose-smoke.py
+++ b/docker/compose-smoke.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Assertions used by the Docker Compose smoke test."""
+
+import argparse
+import json
+import os
+import sys
+import time
+from http.cookiejar import CookieJar
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPCookieProcessor, Request, build_opener
+
+
+def require(condition, message):
+    """Exit with a useful message when a smoke-test assertion fails."""
+    if not condition:
+        raise SystemExit(message)
+
+
+def verify_config(args):
+    """Verify the rendered database settings for PostgreSQL and Django."""
+    config = json.load(sys.stdin)
+    db_service = config['services']['db']
+    web_service = config['services']['web']
+    expected_db_environment = {
+        'POSTGRES_USER': args.database_user,
+        'POSTGRES_DB': args.database_name,
+        'POSTGRES_PASSWORD': args.database_password,
+    }
+    expected_web_environment = {
+        'DB_USER': args.database_user,
+        'DB_NAME': args.database_name,
+        'DB_PASS': args.database_password,
+    }
+
+    for setting, expected in expected_db_environment.items():
+        require(
+            db_service['environment'].get(setting) == expected,
+            f'db environment does not contain {setting}={expected}',
+        )
+    for setting, expected in expected_web_environment.items():
+        require(
+            web_service['environment'].get(setting) == expected,
+            f'web environment does not contain {setting}={expected}',
+        )
+
+    healthcheck = ' '.join(db_service['healthcheck']['test'])
+    require('POSTGRES_USER' in healthcheck, 'database health check does not select POSTGRES_USER')
+    require('POSTGRES_DB' in healthcheck, 'database health check does not select POSTGRES_DB')
+    print('Rendered Compose config passes database checks.')
+
+
+def wait_for_login_page(opener, login_url, timeout_seconds):
+    """Wait for uWSGI to serve the login page."""
+    deadline = time.monotonic() + timeout_seconds
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            with opener.open(login_url, timeout=5) as response:
+                response.read()
+            return
+        except (TimeoutError, URLError) as error:
+            last_error = error
+            time.sleep(1)
+    raise SystemExit(f'web service did not become ready: {last_error}')
+
+
+def verify_endpoint(args):
+    """Log in and prove an authenticated endpoint is served."""
+    username = os.environ['DJANGO_SUPERUSER_USERNAME']
+    password = os.environ['DJANGO_SUPERUSER_PASSWORD']
+    base_url = 'http://127.0.0.1:8080'
+    login_url = f'{base_url}/login/'
+    cookie_jar = CookieJar()
+    opener = build_opener(HTTPCookieProcessor(cookie_jar))
+
+    wait_for_login_page(opener, login_url, args.timeout)
+    csrf_token = next(
+        (cookie.value for cookie in cookie_jar if cookie.name == 'csrftoken'),
+        None,
+    )
+    require(csrf_token is not None, 'login page did not set a CSRF cookie')
+
+    login_data = urlencode({
+        'username': username,
+        'password': password,
+        'csrfmiddlewaretoken': csrf_token,
+    }).encode()
+    login_request = Request(
+        login_url,
+        data=login_data,
+        headers={'Referer': login_url},
+        method='POST',
+    )
+    with opener.open(login_request, timeout=5) as response:
+        response.read()
+
+    with opener.open(f'{base_url}/current/all.json/', timeout=5) as response:
+        status = json.load(response)
+    require(
+        status.get('currentUser') == username,
+        'authenticated endpoint did not return the smoke-test user',
+    )
+    print(f'Authenticated endpoint returned currentUser={username}.')
+
+
+def parse_args():
+    """Parse smoke-test helper arguments."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    config_parser = subparsers.add_parser('config')
+    config_parser.add_argument('database_user')
+    config_parser.add_argument('database_name')
+    config_parser.add_argument('database_password')
+    config_parser.set_defaults(handler=verify_config)
+
+    endpoint_parser = subparsers.add_parser('endpoint')
+    endpoint_parser.add_argument('--timeout', type=int, default=60)
+    endpoint_parser.set_defaults(handler=verify_endpoint)
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    parsed_args = parse_args()
+    parsed_args.handler(parsed_args)

--- a/test-docker-compose.sh
+++ b/test-docker-compose.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+smoke_repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+smoke_compose_file="${smoke_repo_root}/docker-compose.yaml"
+smoke_temp_dir=$(mktemp -d /tmp/fss-compose-smoke.XXXXXX)
+smoke_env_file="${smoke_temp_dir}/smoke.env"
+smoke_project="fss-bug08-smoke-$$"
+smoke_web_container=""
+
+smoke_db_user="fss_smoke_user"
+smoke_db_name="fss_smoke_database"
+smoke_db_password="fss_smoke_database_password"
+smoke_admin_user="fss_smoke_admin"
+smoke_admin_password="fss_smoke_admin_password"
+
+cat > "${smoke_env_file}" <<EOF
+DB_USER=${smoke_db_user}
+DB_NAME=${smoke_db_name}
+DB_PASS=${smoke_db_password}
+DJANGO_SECRET_KEY=fss-smoke-secret-key-with-more-than-fifty-characters-1234567890
+DJANGO_SUPERUSER_USERNAME=${smoke_admin_user}
+DJANGO_SUPERUSER_PASSWORD=${smoke_admin_password}
+DJANGO_SUPERUSER_EMAIL=smoke@example.com
+ALLOWED_HOSTS=localhost,127.0.0.1
+CSRF_TRUSTED_ORIGINS=
+CORS_ALLOWED_ORIGINS=
+SESSION_COOKIE_SECURE=false
+CSRF_COOKIE_SECURE=false
+SECURE_HSTS_SECONDS=0
+EOF
+
+smoke_compose=(
+    docker compose
+    --project-name "${smoke_project}"
+    --env-file "${smoke_env_file}"
+    --file "${smoke_compose_file}"
+)
+
+cleanup() {
+    smoke_result=$?
+    trap - EXIT
+    if [[ ${smoke_result} -ne 0 ]]
+    then
+        if [[ -n "${smoke_web_container}" ]]
+        then
+            docker logs "${smoke_web_container}" || true
+        fi
+        "${smoke_compose[@]}" logs db || true
+    fi
+    "${smoke_compose[@]}" down --rmi local --volumes --remove-orphans >/dev/null 2>&1 || true
+    rm -rf -- "${smoke_temp_dir}"
+    exit "${smoke_result}"
+}
+trap cleanup EXIT
+
+required_database_settings=(DB_USER DB_NAME DB_PASS)
+for missing_setting in "${required_database_settings[@]}"
+do
+    smoke_environment=(-u DB_USER -u DB_NAME -u DB_PASS)
+    for present_setting in "${required_database_settings[@]}"
+    do
+        if [[ "${present_setting}" != "${missing_setting}" ]]
+        then
+            smoke_environment+=("${present_setting}=smoke-required-setting")
+        fi
+    done
+    if env "${smoke_environment[@]}" \
+        docker compose \
+        --env-file /dev/null \
+        --file "${smoke_compose_file}" \
+        config >/dev/null 2>&1
+    then
+        echo "Compose config unexpectedly accepted missing ${missing_setting}." >&2
+        exit 1
+    fi
+done
+echo "Compose rejects missing database settings."
+
+"${smoke_compose[@]}" config --format json |
+    python3 "${smoke_repo_root}/docker/compose-smoke.py" \
+        config \
+        "${smoke_db_user}" \
+        "${smoke_db_name}" \
+        "${smoke_db_password}"
+
+"${smoke_compose[@]}" build web
+"${smoke_compose[@]}" up --detach --wait db
+smoke_web_container=$("${smoke_compose[@]}" run --detach --no-deps web)
+
+docker exec \
+    "${smoke_web_container}" \
+    /venv/bin/python \
+    /code/docker/compose-smoke.py \
+    endpoint
+
+echo "Fresh-volume Docker Compose smoke test passed."


### PR DESCRIPTION
## Description

A rendered config check alone cannot prove that a new PostgreSQL volume supports application startup. Exercise distinct database and user names through migrations and authenticated HTTP access in an isolated project, run the smoke test in CI, and record BUG-08 as resolved.

## Summary by Sourcery

Add a Docker Compose smoke test to verify fresh database volumes and authenticated application startup.

CI:
- Run the Docker Compose smoke test in CI to exercise fresh Compose deployments with migrations and authentication.

Documentation:
- Document how to run the Docker Compose smoke test to validate a fresh deployment.

Tests:
- Introduce a Docker Compose smoke-test script and helper to assert database config rendering, readiness checks, and authenticated HTTP access against an isolated project.