### PR TITLE
Protect retired asset identities

### DIFF
--- a/assets/admin.py
+++ b/assets/admin.py
@@ -7,6 +7,25 @@ from django.contrib import admin
 from .models import Asset, AssetCommand
 
 
+@admin.register(Asset)
+class AssetAdmin(admin.ModelAdmin):
+    """Manage an asset's lifecycle without deleting its identity."""
+
+    list_display = ('name', 'is_active', 'retired_at')
+    list_filter = ('retired_at', )
+    fields = ('name', 'retired_at')
+    actions = None
+
+    @admin.display(boolean=True, description='Active')
+    def is_active(self, obj):
+        """Return whether the asset remains available to active APIs."""
+        return obj.retired_at is None
+
+    def has_delete_permission(self, request, obj=None):
+        """Assets are retired, never deleted through the admin."""
+        return False
+
+
 @admin.register(AssetCommand)
 class AssetCommandAdmin(admin.ModelAdmin):
     """
@@ -29,6 +48,3 @@ class AssetCommandAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
-
-
-admin.site.register(Asset)

--- a/assets/migrations/0013_asset_retirement_and_command_protection.py
+++ b/assets/migrations/0013_asset_retirement_and_command_protection.py
@@ -1,0 +1,30 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0012_assetcommand_notify'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='asset',
+            name='retired_at',
+            field=models.DateTimeField(
+                blank=True,
+                db_index=True,
+                help_text='Retire this asset instead of deleting its identity and audit history.',
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='assetcommand',
+            name='asset',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                to='assets.asset',
+            ),
+        ),
+    ]

--- a/assets/models.py
+++ b/assets/models.py
@@ -6,7 +6,19 @@ import uuid
 
 from django.conf import settings
 from django.contrib.gis.db import models
+from django.db.models.deletion import ProtectedError
 from django.utils import timezone
+
+
+class AssetQuerySet(models.QuerySet):
+    """Require assets to be retired instead of deleted through Django."""
+
+    def delete(self):
+        protected = list(self)
+        raise ProtectedError(
+            "Assets cannot be deleted; set retired_at instead.",
+            protected,
+        )
 
 
 class Asset(models.Model):
@@ -14,9 +26,23 @@ class Asset(models.Model):
     An asset
     """
     name = models.CharField(max_length=100, unique=True)
+    retired_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="Retire this asset instead of deleting its identity and audit history.",
+    )
+
+    objects = AssetQuerySet.as_manager()
 
     def __str__(self):
         return f"Asset: {self.name}"
+
+    def delete(self, using=None, keep_parents=False):
+        raise ProtectedError(
+            "Assets cannot be deleted; set retired_at instead.",
+            [self],
+        )
 
 
 class AssetSearchProgress(models.Model):
@@ -96,7 +122,7 @@ class AssetCommand(models.Model):
     """
     Command for asset
     """
-    asset = models.ForeignKey(Asset, on_delete=models.CASCADE)
+    asset = models.ForeignKey(Asset, on_delete=models.PROTECT)
     timestamp = models.DateTimeField(default=timezone.now)
     COMMAND_CHOICES = (
         ('RTL', "Return to Launch"),

--- a/assets/tests/test_admin.py
+++ b/assets/tests/test_admin.py
@@ -4,8 +4,19 @@ Tests for the assets admin.
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase
 
-from assets.admin import AssetCommandAdmin
-from assets.models import AssetCommand
+from assets.admin import AssetAdmin, AssetCommandAdmin
+from assets.models import Asset, AssetCommand
+
+
+class AssetAdminTest(TestCase):
+    """Assets leave service through retirement, not admin deletion."""
+
+    def test_delete_paths_are_disabled(self):
+        """Neither object nor bulk deletion is available for assets."""
+        asset_admin = AssetAdmin(Asset, AdminSite())
+
+        self.assertFalse(asset_admin.has_delete_permission(None))
+        self.assertIsNone(asset_admin.actions)
 
 
 class AssetCommandAdminTest(TestCase):

--- a/assets/tests/test_models.py
+++ b/assets/tests/test_models.py
@@ -1,0 +1,49 @@
+"""Tests for asset lifecycle and audit relationships."""
+
+# pylint: disable=missing-function-docstring
+
+from django.db.models.deletion import ProtectedError
+from django.test import TestCase
+from django.utils import timezone
+
+from assets.models import Asset, AssetCommand
+
+
+class AssetLifecycleTest(TestCase):
+    """Asset identities are retired and retained rather than deleted."""
+
+    def test_instance_delete_requires_retirement(self):
+        asset = Asset.objects.create(name='Instance delete')
+
+        with self.assertRaisesMessage(ProtectedError, 'set retired_at instead'):
+            asset.delete()
+
+        self.assertTrue(Asset.objects.filter(pk=asset.pk).exists())
+
+    def test_queryset_delete_requires_retirement(self):
+        asset = Asset.objects.create(name='Queryset delete')
+
+        with self.assertRaisesMessage(ProtectedError, 'set retired_at instead'):
+            Asset.objects.filter(pk=asset.pk).delete()
+
+        self.assertTrue(Asset.objects.filter(pk=asset.pk).exists())
+
+    def test_retirement_is_reversible(self):
+        asset = Asset.objects.create(name='Reactivatable')
+        asset.retired_at = timezone.now()
+        asset.save(update_fields=['retired_at'])
+        asset.retired_at = None
+        asset.save(update_fields=['retired_at'])
+
+        asset.refresh_from_db()
+        self.assertIsNone(asset.retired_at)
+
+    def test_command_protects_asset_from_collector_deletion(self):
+        asset = Asset.objects.create(name='Protected command')
+        command = AssetCommand.objects.create(asset=asset, command='RTL')
+
+        with self.assertRaises(ProtectedError):
+            asset.delete()
+
+        self.assertTrue(Asset.objects.filter(pk=asset.pk).exists())
+        self.assertTrue(AssetCommand.objects.filter(pk=command.pk).exists())

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -95,6 +95,26 @@ class AssetAPITest(TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertFalse(AssetCommandConfirmation.objects.exists())
 
+    def test_retired_asset_rejects_commands_and_confirmations(self):
+        """A retired identity cannot receive new commands through the web API."""
+        self.asset.retired_at = timezone.now()
+        self.asset.save(update_fields=['retired_at'])
+        self.client.force_login(self.user)
+
+        confirm_response = self.client.post(
+            reverse('asset_command_confirm', kwargs={'asset_id': self.asset.pk}),
+            {'command': 'TERM'},
+        )
+        command_response = self.client.post(
+            reverse('asset_command_set', kwargs={'asset_id': self.asset.pk}),
+            {'command': 'RTL'},
+        )
+
+        self.assertEqual(confirm_response.status_code, 404)
+        self.assertEqual(command_response.status_code, 404)
+        self.assertFalse(AssetCommandConfirmation.objects.exists())
+        self.assertFalse(AssetCommand.objects.exists())
+
     def test_asset_command_confirm_issues_bound_token(self):
         """A destructive command confirmation returns a short-lived token."""
         self.client.force_login(self.user)

--- a/assets/views.py
+++ b/assets/views.py
@@ -315,7 +315,7 @@ def asset_command_confirm(request, asset_id):
     """
     Issue short-lived, single-use evidence for a destructive command.
     """
-    asset = get_object_or_404(Asset, pk=asset_id)
+    asset = get_object_or_404(Asset, pk=asset_id, retired_at__isnull=True)
     if request.method != "POST":
         return HttpResponseBadRequest("Only POST is supported")
 
@@ -374,7 +374,7 @@ def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-sta
     """
     Set the command for a given asset
     """
-    asset = get_object_or_404(Asset, pk=asset_id)
+    asset = get_object_or_404(Asset, pk=asset_id, retired_at__isnull=True)
     if request.method == "POST":
         point = None
         altitude = None

--- a/config/tests/test_views.py
+++ b/config/tests/test_views.py
@@ -4,6 +4,7 @@ Tests for the Config API
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from assets.models import Asset
 from config.models import AssetConfig, ServerConfig, SMMConfig
@@ -49,6 +50,17 @@ class ConfigViewTest(TestCase):
         self.assertEqual(len(data['assets']), 1)
         self.assertEqual(data['assets'][0]['name'], 'Test Drone')
         self.assertEqual(data['assets'][0]['smm_name'], 'SMM Server')
+
+    def test_config_data_json_hides_retired_assets(self):
+        """Retired identities are not offered as active configuration targets."""
+        self.asset.retired_at = timezone.now()
+        self.asset.save(update_fields=['retired_at'])
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse('config_data_json'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['assets'], [])
 
     def test_config_data_json_asset_without_config(self):
         """An asset with no AssetConfig reports null SMM fields rather than erroring."""

--- a/config/views.py
+++ b/config/views.py
@@ -24,7 +24,7 @@ def config_data_json(request):
     """
     Return all configuration data as JSON
     """
-    assets = list(Asset.objects.all())
+    assets = list(Asset.objects.filter(retired_at__isnull=True))
     configs_by_asset_id = {c.asset_id: c for c in AssetConfig.objects.filter(asset__in=assets).select_related('smm')}
 
     fss_servers = []

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -43,6 +43,18 @@ class StatusAPITest(TestCase):
         self.assertEqual(data['assets'][0]['asset']['name'], 'Test Drone')
         self.assertIn('csrfToken', data)
 
+    def test_retired_asset_is_hidden_from_active_endpoints(self):
+        """Retired identities leave status and asset-list responses."""
+        self.asset.retired_at = timezone.now()
+        self.asset.save(update_fields=['retired_at'])
+        self.client.force_login(self.user)
+
+        status_response = self.client.get(reverse('all_status_data'))
+        list_response = self.client.get(reverse('asset_list'))
+
+        self.assertEqual(status_response.json()['assets'], [])
+        self.assertEqual(list_response.json()['assets'], [])
+
     def test_all_status_data_server_now(self):
         """The status response carries the server's current time (epoch-ms)."""
         self.client.login(username='testuser', password='password')

--- a/main/views.py
+++ b/main/views.py
@@ -26,7 +26,7 @@ def asset_list(request):
     """
     Return the know assets as a json array
     """
-    assets = list(Asset.objects.all())
+    assets = list(Asset.objects.filter(retired_at__isnull=True))
     configs_by_asset_id = {c.asset_id: c for c in AssetConfig.objects.filter(asset__in=assets).select_related('smm')}
     assets_list = []
     for asset in assets:
@@ -85,7 +85,7 @@ def all_status_data(request):
         }
         data['servers'].append(server_details)
 
-    assets = Asset.objects.all()
+    assets = Asset.objects.filter(retired_at__isnull=True)
     data['assets'] = bulk_asset_status_data(assets)
 
     response = JsonResponse(data)


### PR DESCRIPTION
## Description

Command records are safety audit data, so deleting their parent asset must not cascade that history away. A reversible retirement state removes assets from active web operations while preserving the identity and blocking ordinary Django/admin deletion paths.

## Summary by Sourcery

Introduce a reversible retirement state for assets and prevent deletion to preserve identity and audit history, while excluding retired assets from active web APIs and configuration endpoints.

New Features:
- Add a reversible retirement timestamp field to assets to support lifecycle management without deletion.

Bug Fixes:
- Protect asset-command relationships by preventing asset deletion and using a non-cascading foreign key so command audit data is retained.

Enhancements:
- Override asset deletion at both model and queryset levels to raise a protected error and enforce retirement usage.
- Update views and admin to hide retired assets from active status, configuration, and command endpoints while allowing lifecycle management through admin.
- Register a dedicated Asset admin with constrained fields, active indicator, and disabled delete actions.

Tests:
- Add model, admin, and view tests verifying asset retirement behavior, deletion protection, and exclusion of retired assets from active responses.