### PR TITLE
Enforce one asset configuration per asset

### DIFF
--- a/config/asset_configs.py
+++ b/config/asset_configs.py
@@ -15,6 +15,14 @@ class DuplicateAssetConfigError(Exception):
         super().__init__(f"Duplicate AssetConfig rows for asset IDs: {self.asset_ids}")
 
 
+def duplicate_asset_config_response(asset_ids):
+    """Build the public cleanup-window response without credential data."""
+    return JsonResponse({
+        'error': 'Multiple SMM configurations exist for one or more assets.',
+        'duplicate_asset_ids': asset_ids,
+    }, status=409)
+
+
 def asset_configs_by_asset_id(assets):
     """Return one config per asset or report every conflicting asset ID."""
     configs = list(
@@ -41,7 +49,4 @@ def active_assets_with_configs():
     try:
         return (assets, asset_configs_by_asset_id(assets)), None
     except DuplicateAssetConfigError as exc:
-        return None, JsonResponse({
-            'error': 'Multiple SMM configurations exist for one or more assets.',
-            'duplicate_asset_ids': exc.asset_ids,
-        }, status=409)
+        return None, duplicate_asset_config_response(exc.asset_ids)

--- a/config/migrations/0002_assetconfig_one_per_asset.py
+++ b/config/migrations/0002_assetconfig_one_per_asset.py
@@ -1,0 +1,44 @@
+import django.db.models.deletion
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def require_unique_asset_configs(apps, _schema_editor):
+    """Abort without exposing credentials when legacy conflicts remain."""
+    asset_config = apps.get_model('config', 'AssetConfig')
+    duplicate_asset_ids = list(
+        asset_config.objects
+        .values('asset_id')
+        .annotate(row_count=Count('pk'))
+        .filter(row_count__gt=1)
+        .order_by('asset_id')
+        .values_list('asset_id', flat=True)
+    )
+    if duplicate_asset_ids:
+        raise RuntimeError(
+            'Duplicate AssetConfig rows must be resolved for asset IDs: '
+            + ', '.join(str(asset_id) for asset_id in duplicate_asset_ids)
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('config', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(require_unique_asset_configs, migrations.RunPython.noop),
+        migrations.RemoveIndex(
+            model_name='assetconfig',
+            name='config_asse_asset_i_c1e6c4_idx',
+        ),
+        migrations.AlterField(
+            model_name='assetconfig',
+            name='asset',
+            field=models.OneToOneField(
+                on_delete=django.db.models.deletion.CASCADE,
+                to='assets.asset',
+            ),
+        ),
+    ]

--- a/config/models.py
+++ b/config/models.py
@@ -79,7 +79,7 @@ class AssetConfig(models.Model):
     """
     Configuration for an asset
     """
-    asset = models.ForeignKey(Asset, on_delete=models.CASCADE)
+    asset = models.OneToOneField(Asset, on_delete=models.CASCADE)
     smm = models.ForeignKey(SMMConfig, on_delete=models.PROTECT)
     smm_login = models.CharField(max_length=50)
     smm_password = models.CharField(max_length=255)
@@ -89,6 +89,5 @@ class AssetConfig(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=['asset', ]),
             models.Index(fields=['smm', ]),
         ]

--- a/config/tests/test_audit_asset_configs.py
+++ b/config/tests/test_audit_asset_configs.py
@@ -3,6 +3,7 @@
 # pylint: disable=missing-function-docstring
 
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -35,20 +36,16 @@ class AuditAssetConfigsTest(TestCase):
         self.assertIn('No duplicate AssetConfig rows found', self.run_command())
 
     def test_duplicates_report_only_asset_identity_and_count(self):
-        for login, password in (('one', 'first-secret'), ('two', 'second-secret')):
-            AssetConfig.objects.create(
-                asset=self.asset,
-                smm=self.smm,
-                smm_login=login,
-                smm_password=password,
-            )
         stdout = StringIO()
+        values = patch.object(AssetConfig.objects, 'values').start()
+        self.addCleanup(patch.stopall)
+        values.return_value.annotate.return_value.filter.return_value.order_by.return_value = [
+            {'asset_id': self.asset.pk, 'row_count': 2},
+        ]
 
         with self.assertRaises(CommandError):
             call_command('audit_asset_configs', stdout=stdout)
 
         output = stdout.getvalue()
         self.assertIn(f'asset_id={self.asset.pk} rows=2', output)
-        self.assertNotIn('one', output)
-        self.assertNotIn('two', output)
         self.assertNotIn('secret', output)

--- a/config/tests/test_migrations.py
+++ b/config/tests/test_migrations.py
@@ -1,0 +1,66 @@
+"""Migration tests for enforcing AssetConfig cardinality."""
+
+# pylint: disable=missing-function-docstring
+
+import importlib
+
+from django.db import IntegrityError, connection, transaction
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class AssetConfigCardinalityMigrationTest(TransactionTestCase):
+    """The migration refuses ambiguous credentials before adding uniqueness."""
+
+    migrate_from = [('config', '0001_initial')]
+    migrate_to = [('config', '0002_assetconfig_one_per_asset')]
+
+    def setUp(self):
+        self.executor = MigrationExecutor(connection)
+        self.executor.migrate(self.migrate_from)
+        self.old_apps = self.executor.loader.project_state(self.migrate_from).apps
+
+    def tearDown(self):
+        self.old_apps.get_model('config', 'AssetConfig').objects.all().delete()
+        self.executor = MigrationExecutor(connection)
+        self.executor.migrate(self.executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def create_fixture(self):
+        asset = self.old_apps.get_model('assets', 'Asset').objects.create(name='Migration asset')
+        smm = self.old_apps.get_model('config', 'SMMConfig').objects.create(
+            name='Migration SMM',
+            address='smm.example',
+        )
+        return asset, smm, self.old_apps.get_model('config', 'AssetConfig')
+
+    def test_precheck_lists_ids_without_credentials(self):
+        asset, smm, asset_config = self.create_fixture()
+        asset_config.objects.create(asset=asset, smm=smm, smm_login='one', smm_password='first-secret')
+        asset_config.objects.create(asset=asset, smm=smm, smm_login='two', smm_password='second-secret')
+        migration = importlib.import_module('config.migrations.0002_assetconfig_one_per_asset')
+
+        with self.assertRaises(RuntimeError) as raised:
+            migration.require_unique_asset_configs(self.old_apps, None)
+
+        self.assertIn(str(asset.pk), str(raised.exception))
+        self.assertNotIn('one', str(raised.exception))
+        self.assertNotIn('two', str(raised.exception))
+        self.assertNotIn('secret', str(raised.exception))
+        asset_config.objects.all().delete()
+
+    def test_clean_migration_enforces_one_optional_config(self):
+        asset, smm, asset_config = self.create_fixture()
+        asset_config.objects.create(asset=asset, smm=smm, smm_login='one', smm_password='secret')
+
+        self.executor = MigrationExecutor(connection)
+        self.executor.migrate(self.migrate_to)
+        current_apps = self.executor.loader.project_state(self.migrate_to).apps
+        current_asset_config = current_apps.get_model('config', 'AssetConfig')
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            current_asset_config.objects.create(
+                asset_id=asset.pk,
+                smm_id=smm.pk,
+                smm_login='two',
+                smm_password='other',
+            )

--- a/config/tests/test_views.py
+++ b/config/tests/test_views.py
@@ -1,12 +1,15 @@
 """
 Tests for the Config API
 """
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from assets.models import Asset
+from config.asset_configs import duplicate_asset_config_response
 from config.models import AssetConfig, ServerConfig, SMMConfig
 
 
@@ -80,15 +83,11 @@ class ConfigViewTest(TestCase):
 
     def test_config_data_json_reports_duplicate_asset_configs(self):
         """Legacy conflicting rows are reported instead of silently collapsed."""
-        AssetConfig.objects.create(
-            asset=self.asset,
-            smm=self.smm_server,
-            smm_login='other-user',
-            smm_password='other-secret',
-        )
         self.client.force_login(self.user)
 
-        response = self.client.get(reverse('config_data_json'))
+        error = duplicate_asset_config_response([self.asset.pk])
+        with patch('config.views.active_assets_with_configs', return_value=(None, error)):
+            response = self.client.get(reverse('config_data_json'))
 
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.json()['duplicate_asset_ids'], [self.asset.pk])

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -1,6 +1,8 @@
 """
 Test the main API
 """
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
 from django.test import Client, TestCase
@@ -8,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetStatus
+from config.asset_configs import duplicate_asset_config_response
 from config.models import AssetConfig, ServerConfig, SMMConfig
 from fss.satisfies import satisfies
 
@@ -170,13 +173,11 @@ class StatusAPITest(TestCase):
 
     def test_asset_list_reports_duplicate_asset_configs(self):
         """Legacy conflicting rows produce an explicit configuration error."""
-        first_smm = SMMConfig.objects.create(name='First SMM', address='2.2.2.2')
-        second_smm = SMMConfig.objects.create(name='Second SMM', address='3.3.3.3')
-        AssetConfig.objects.create(asset=self.asset, smm=first_smm, smm_login='one', smm_password='first-secret')
-        AssetConfig.objects.create(asset=self.asset, smm=second_smm, smm_login='two', smm_password='second-secret')
         self.client.force_login(self.user)
 
-        response = self.client.get(reverse('asset_list'))
+        error = duplicate_asset_config_response([self.asset.pk])
+        with patch('main.views.active_assets_with_configs', return_value=(None, error)):
+            response = self.client.get(reverse('asset_list'))
 
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.json()['duplicate_asset_ids'], [self.asset.pk])


### PR DESCRIPTION
## Description

The UI and FSS database reader both require an optional one-to-one SMM configuration. Block migration when legacy conflicts remain, then enforce that contract in the database so credentials can no longer depend on row ordering.

## Summary by Sourcery

Enforce a one-to-one AssetConfig per asset and guard the migration and APIs against legacy duplicate configurations without exposing credentials.

New Features:
- Add a JSON API error response helper for assets with multiple SMM configurations.

Enhancements:
- Centralize duplicate-asset configuration error construction and reuse it across config and main views.
- Tighten AssetConfig cardinality to a one-to-one relation with Asset and remove the now-redundant asset index.

Tests:
- Add migration tests to ensure duplicate AssetConfig rows block the migration and that the new one-to-one constraint is enforced.
- Update API and audit tests to assert duplicate configuration handling using patched helpers instead of creating real conflicting credentials.