### PR TITLE
Add command operation identifiers

### DIFF
--- a/assets/migrations/0015_command_operation_id.py
+++ b/assets/migrations/0015_command_operation_id.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0014_assetcommandack'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assetcommand',
+            name='operation_id',
+            field=models.UUIDField(blank=True, null=True, unique=True),
+        ),
+        migrations.AddField(
+            model_name='assetcommandconfirmation',
+            name='operation_id',
+            field=models.UUIDField(blank=True, db_index=True, null=True),
+        ),
+    ]

--- a/assets/models.py
+++ b/assets/models.py
@@ -136,6 +136,10 @@ class AssetCommand(models.Model):
         ('MAN', "Manual"),
     )
     command = models.CharField(max_length=6, choices=COMMAND_CHOICES)
+    # Stable identity for one logical operator action. Web submissions require
+    # this value, while NULL remains valid for legacy rows and commands written
+    # directly by older FSS components.
+    operation_id = models.UUIDField(null=True, blank=True, unique=True)
     DESTRUCTIVE_COMMANDS = ('DISARM', 'TERM')
     REQUIRES_POSITION = ('GOTO', )
     position = models.PointField(geography=True, null=True, blank=True)
@@ -262,6 +266,10 @@ class AssetCommandConfirmation(models.Model):
     consumes it atomically when it queues the corresponding command.
     """
     token = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # Bind destructive confirmation evidence to the same logical operation as
+    # the command it authorizes. NULL preserves short-lived rows created before
+    # the idempotency contract was deployed.
+    operation_id = models.UUIDField(null=True, blank=True, db_index=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='+')
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE)
     command = models.CharField(max_length=6, choices=AssetCommand.COMMAND_CHOICES)


### PR DESCRIPTION
## Description

Command submissions need a stable database identity so repeated requests can resolve to one audit row. Nullable fields preserve compatibility with legacy command and confirmation records while the command constraint enforces uniqueness for new operations.

## Summary by Sourcery

Introduce stable operation identifiers for asset commands and their confirmations to support idempotent command handling and auditing.

New Features:
- Add an optional unique operation identifier field to asset commands to represent a single logical operator action.
- Add an optional operation identifier field to asset command confirmations to associate confirmation evidence with the corresponding operation.

Enhancements:
- Create a schema migration to add operation identifier fields and related indexes to asset command and confirmation models.