### PR TITLE
Make command submission idempotent

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -150,7 +150,7 @@ class AssetCommand(models.Model):
     @classmethod
     def allowed_parameter_names(cls, command):
         """Return the complete POST parameter contract for a command."""
-        parameter_names = {'command'}
+        parameter_names = {'command', 'operation_id'}
         if command in cls.REQUIRES_POSITION:
             parameter_names.update(('latitude', 'longitude'))
         if command in cls.REQUIRES_ALTITUDE:

--- a/assets/tests/test_models.py
+++ b/assets/tests/test_models.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=missing-function-docstring
 
+import uuid
+
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.db.models.deletion import ProtectedError
@@ -59,6 +61,20 @@ class AssetLifecycleTest(TestCase):
 
         command.refresh_from_db()
         self.assertIsNone(command.issued_by)
+
+    def test_operation_id_is_unique_but_legacy_nulls_are_allowed(self):
+        asset = Asset.objects.create(name='Operation identity')
+        operation_id = uuid.uuid4()
+        AssetCommand.objects.create(
+            asset=asset, command='RTL', operation_id=operation_id,
+        )
+        AssetCommand.objects.create(asset=asset, command='HOLD')
+        AssetCommand.objects.create(asset=asset, command='RON')
+
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            AssetCommand.objects.create(
+                asset=asset, command='MAN', operation_id=operation_id,
+            )
 
 
 class AssetCommandAckTest(TestCase):

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for the Asset API
 """
+import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -29,13 +30,25 @@ class AssetAPITest(TestCase):
         self.user = get_user_model().objects.create_user(username='testuser', password='testpass')
         AssetRTT.objects.create(asset=self.asset, rtt=10)
 
-    def _issue_confirmation(self, command, *, asset=None, client=None):
+    @staticmethod
+    def _command_payload(command, *, operation_id=None, **parameters):
+        return {
+            'command': command,
+            'operation_id': str(operation_id or uuid.uuid4()),
+            **parameters,
+        }
+
+    def _issue_confirmation(self, command, *, operation_id=None, asset=None, client=None):
         target_asset = asset or self.asset
         target_client = client or self.client
+        operation_id = operation_id or uuid.uuid4()
         url = reverse('asset_command_confirm', kwargs={'asset_id': target_asset.pk})
-        response = target_client.post(url, {'command': command})
+        response = target_client.post(
+            url,
+            self._command_payload(command, operation_id=operation_id),
+        )
         self.assertEqual(response.status_code, 200)
-        return response.json()['confirmation_token']
+        return response.json()['confirmation_token'], operation_id
 
     def _get_asset_status(self, asset=None):
         target_asset = asset or self.asset
@@ -84,7 +97,7 @@ class AssetAPITest(TestCase):
         self.assertLess(abs(refreshed_expiry - expected_expiry), timedelta(seconds=5))
 
         command_url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(command_url, {'command': 'RTL'})
+        response = self.client.post(command_url, self._command_payload('RTL'))
         self.assertEqual(response.status_code, 200)
         self.assertTrue(AssetCommand.objects.filter(asset=self.asset, command='RTL').exists())
 
@@ -103,11 +116,11 @@ class AssetAPITest(TestCase):
 
         confirm_response = self.client.post(
             reverse('asset_command_confirm', kwargs={'asset_id': self.asset.pk}),
-            {'command': 'TERM'},
+            self._command_payload('TERM'),
         )
         command_response = self.client.post(
             reverse('asset_command_set', kwargs={'asset_id': self.asset.pk}),
-            {'command': 'RTL'},
+            self._command_payload('RTL'),
         )
 
         self.assertEqual(confirm_response.status_code, 404)
@@ -119,17 +132,55 @@ class AssetAPITest(TestCase):
         """A destructive command confirmation returns a short-lived token."""
         self.client.force_login(self.user)
         before = timezone.now()
+        operation_id = uuid.uuid4()
         url = reverse('asset_command_confirm', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(url, {'command': 'DISARM'})
+        response = self.client.post(
+            url,
+            self._command_payload('DISARM', operation_id=operation_id),
+        )
 
         self.assertEqual(response.status_code, 200)
         confirmation = AssetCommandConfirmation.objects.get(token=response.json()['confirmation_token'])
         self.assertEqual(confirmation.user, self.user)
         self.assertEqual(confirmation.asset, self.asset)
         self.assertEqual(confirmation.command, 'DISARM')
+        self.assertEqual(confirmation.operation_id, operation_id)
         self.assertGreaterEqual(confirmation.expires_at, before + COMMAND_CONFIRMATION_TTL)
         response_expiry = parse_datetime(response.json()['expires_at'])
         self.assertLess(abs(response_expiry - confirmation.expires_at), timedelta(milliseconds=1))
+
+    def test_asset_command_confirm_requires_valid_operation_id(self):
+        """Destructive evidence cannot be issued without an operation UUID."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_confirm', kwargs={'asset_id': self.asset.pk})
+
+        missing = self.client.post(url, {'command': 'TERM'})
+        malformed = self.client.post(
+            url,
+            {'command': 'TERM', 'operation_id': 'not-a-uuid'},
+        )
+
+        self.assertEqual(missing.status_code, 400)
+        self.assertEqual(malformed.status_code, 400)
+        self.assertFalse(AssetCommandConfirmation.objects.exists())
+
+    def test_asset_command_confirm_reuses_live_evidence_for_operation(self):
+        """Repeated preparation returns one operation-bound token."""
+        self.client.force_login(self.user)
+        operation_id = uuid.uuid4()
+        url = reverse('asset_command_confirm', kwargs={'asset_id': self.asset.pk})
+        payload = self._command_payload('TERM', operation_id=operation_id)
+
+        first = self.client.post(url, payload)
+        second = self.client.post(url, payload)
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(
+            first.json()['confirmation_token'],
+            second.json()['confirmation_token'],
+        )
+        self.assertEqual(AssetCommandConfirmation.objects.count(), 1)
 
     def test_asset_command_confirm_rejects_routine_command(self):
         """Confirmation evidence is issued only for destructive commands."""
@@ -157,13 +208,101 @@ class AssetAPITest(TestCase):
         """Test setting RTL command."""
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(url, {'command': 'RTL'})
+        response = self.client.post(url, self._command_payload('RTL'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), 'Queued')
 
         cmd = AssetCommand.objects.filter(asset=self.asset).latest('timestamp')
         self.assertEqual(cmd.command, 'RTL')
         self.assertEqual(cmd.issued_by, self.user)
+        self.assertIsNotNone(cmd.operation_id)
+
+    def test_asset_command_set_requires_valid_operation_id(self):
+        """Every authenticated web command must carry an operation UUID."""
+        self.client.force_login(self.user)
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+
+        missing = self.client.post(url, {'command': 'RTL'})
+        malformed = self.client.post(
+            url,
+            {'command': 'RTL', 'operation_id': 'not-a-uuid'},
+        )
+
+        self.assertEqual(missing.status_code, 400)
+        self.assertEqual(malformed.status_code, 400)
+        self.assertFalse(AssetCommand.objects.exists())
+
+    def test_asset_command_set_replays_identical_operation(self):
+        """An identical retry returns success without a second command row."""
+        self.client.force_login(self.user)
+        operation_id = uuid.uuid4()
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        payload = self._command_payload(
+            'GOTO', operation_id=operation_id,
+            latitude=-43.5, longitude=172.6,
+        )
+
+        first = self.client.post(url, payload)
+        AssetRTT.objects.filter(asset=self.asset).delete()
+        replay = self.client.post(url, payload)
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(replay.status_code, 200)
+        self.assertEqual(replay.content.decode(), 'Queued')
+        self.assertEqual(AssetCommand.objects.count(), 1)
+        self.assertEqual(AssetCommand.objects.get().operation_id, operation_id)
+
+    def test_asset_command_set_rejects_operation_payload_conflicts(self):
+        """A UUID cannot be reused for a changed command or command payload."""
+        self.client.force_login(self.user)
+        operation_id = uuid.uuid4()
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        first = self._command_payload(
+            'GOTO', operation_id=operation_id,
+            latitude=-43.5, longitude=172.6,
+        )
+        self.assertEqual(self.client.post(url, first).status_code, 200)
+
+        conflicts = (
+            self._command_payload('RTL', operation_id=operation_id),
+            self._command_payload(
+                'GOTO', operation_id=operation_id,
+                latitude=-43.6, longitude=172.6,
+            ),
+        )
+        with self.assertLogs('fss.security', level='WARNING') as logs:
+            responses = [self.client.post(url, payload) for payload in conflicts]
+
+        self.assertTrue(all(response.status_code == 409 for response in responses))
+        self.assertEqual(AssetCommand.objects.count(), 1)
+        self.assertEqual(len(logs.records), 2)
+
+    def test_asset_command_set_rejects_operation_identity_conflicts(self):
+        """A UUID cannot be transferred to another asset or operator."""
+        self.client.force_login(self.user)
+        operation_id = uuid.uuid4()
+        url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
+        payload = self._command_payload('RTL', operation_id=operation_id)
+        self.assertEqual(self.client.post(url, payload).status_code, 200)
+
+        other_asset = Asset.objects.create(name='Other Drone')
+        AssetRTT.objects.create(asset=other_asset, rtt=10)
+        other_asset_url = reverse(
+            'asset_command_set', kwargs={'asset_id': other_asset.pk},
+        )
+        with self.assertLogs('fss.security', level='WARNING'):
+            asset_conflict = self.client.post(other_asset_url, payload)
+
+        other_user = get_user_model().objects.create_user(
+            username='other', password='testpass',
+        )
+        self.client.force_login(other_user)
+        with self.assertLogs('fss.security', level='WARNING'):
+            user_conflict = self.client.post(url, payload)
+
+        self.assertEqual(asset_conflict.status_code, 409)
+        self.assertEqual(user_conflict.status_code, 409)
+        self.assertEqual(AssetCommand.objects.count(), 1)
 
     @satisfies('TC-WEB-013')
     def test_asset_command_set_blocks_asset_without_rtt(self):
@@ -172,7 +311,7 @@ class AssetAPITest(TestCase):
         AssetRTT.objects.filter(asset=self.asset).delete()
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        response = self.client.post(url, {'command': 'RTL'})
+        response = self.client.post(url, self._command_payload('RTL'))
 
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.content.decode(), 'Asset is disconnected: no recent RTT response')
@@ -187,7 +326,7 @@ class AssetAPITest(TestCase):
         rtt.timestamp = timezone.now() - ASSET_CONNECTION_TIMEOUT + timedelta(seconds=5)
         rtt.save(update_fields=['timestamp'])
 
-        response = self.client.post(url, {'command': 'RTL'})
+        response = self.client.post(url, self._command_payload('RTL'))
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(AssetCommand.objects.filter(asset=self.asset, command='RTL').exists())
@@ -196,7 +335,7 @@ class AssetAPITest(TestCase):
         rtt.timestamp = timezone.now() - ASSET_CONNECTION_TIMEOUT - timedelta(seconds=5)
         rtt.save(update_fields=['timestamp'])
 
-        response = self.client.post(url, {'command': 'RTL'})
+        response = self.client.post(url, self._command_payload('RTL'))
 
         self.assertEqual(response.status_code, 409)
         self.assertFalse(AssetCommand.objects.exists())
@@ -206,8 +345,14 @@ class AssetAPITest(TestCase):
         """The issuing user is recorded on the command and surfaced in the API."""
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        token = self._issue_confirmation('TERM')
-        self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        token, operation_id = self._issue_confirmation('TERM')
+        self.client.post(
+            url,
+            self._command_payload(
+                'TERM', operation_id=operation_id,
+                confirmation_token=token,
+            ),
+        )
 
         cmd = AssetCommand.objects.filter(asset=self.asset).latest('timestamp')
         self.assertEqual(cmd.issued_by, self.user)
@@ -221,19 +366,33 @@ class AssetAPITest(TestCase):
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        response = self.client.post(url, {'command': 'DISARM'})
+        response = self.client.post(url, self._command_payload('DISARM'))
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
 
-        token = self._issue_confirmation('DISARM')
-        response = self.client.post(url, {'command': 'DISARM', 'confirmation_token': token})
+        token, operation_id = self._issue_confirmation('DISARM')
+        payload = self._command_payload(
+            'DISARM', operation_id=operation_id, confirmation_token=token,
+        )
+        response = self.client.post(url, payload)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(AssetCommand.objects.filter(command='DISARM').count(), 1)
         self.assertFalse(AssetCommandConfirmation.objects.filter(token=token).exists())
 
-        response = self.client.post(url, {'command': 'DISARM', 'confirmation_token': token})
-        self.assertEqual(response.status_code, 400)
+        response = self.client.post(
+            url,
+            self._command_payload('DISARM', operation_id=operation_id),
+        )
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(AssetCommand.objects.filter(command='DISARM').count(), 1)
+
+        confirmation_response = self.client.post(
+            reverse('asset_command_confirm', kwargs={'asset_id': self.asset.pk}),
+            self._command_payload('DISARM', operation_id=operation_id),
+        )
+        self.assertEqual(confirmation_response.status_code, 200)
+        self.assertTrue(confirmation_response.json()['operation_committed'])
+        self.assertFalse(AssetCommandConfirmation.objects.exists())
 
     @satisfies('TC-WEB-011')
     def test_term_requires_single_use_confirmation(self):
@@ -241,12 +400,18 @@ class AssetAPITest(TestCase):
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        response = self.client.post(url, {'command': 'TERM'})
+        response = self.client.post(url, self._command_payload('TERM'))
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
 
-        token = self._issue_confirmation('TERM')
-        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        token, operation_id = self._issue_confirmation('TERM')
+        response = self.client.post(
+            url,
+            self._command_payload(
+                'TERM', operation_id=operation_id,
+                confirmation_token=token,
+            ),
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(AssetCommand.objects.filter(command='TERM').count(), 1)
         self.assertFalse(AssetCommandConfirmation.objects.filter(token=token).exists())
@@ -254,11 +419,17 @@ class AssetAPITest(TestCase):
     def test_asset_command_set_rejects_expired_confirmation(self):
         """An expired destructive-command confirmation cannot queue a command."""
         self.client.force_login(self.user)
-        token = self._issue_confirmation('TERM')
+        token, operation_id = self._issue_confirmation('TERM')
         AssetCommandConfirmation.objects.filter(token=token).update(expires_at=timezone.now() - timedelta(seconds=1))
 
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        response = self.client.post(
+            url,
+            self._command_payload(
+                'TERM', operation_id=operation_id,
+                confirmation_token=token,
+            ),
+        )
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
 
@@ -266,19 +437,30 @@ class AssetAPITest(TestCase):
         """A malformed token is a validation failure, not a server error."""
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': 'not-a-uuid'})
+        response = self.client.post(
+            url,
+            self._command_payload(
+                'TERM', confirmation_token='not-a-uuid',
+            ),
+        )
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
 
     def test_asset_command_set_rejects_confirmation_for_other_user(self):
         """A token cannot be transferred to another authenticated user."""
         self.client.force_login(self.user)
-        token = self._issue_confirmation('TERM')
+        token, operation_id = self._issue_confirmation('TERM')
         other_user = get_user_model().objects.create_user(username='other', password='testpass')
         self.client.force_login(other_user)
 
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        response = self.client.post(
+            url,
+            self._command_payload(
+                'TERM', operation_id=operation_id,
+                confirmation_token=token,
+            ),
+        )
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
         self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
@@ -286,12 +468,18 @@ class AssetAPITest(TestCase):
     def test_asset_command_set_rejects_confirmation_for_other_asset(self):
         """A token cannot be used against a different asset."""
         self.client.force_login(self.user)
-        token = self._issue_confirmation('TERM')
+        token, operation_id = self._issue_confirmation('TERM')
         other_asset = Asset.objects.create(name='Other Drone')
         AssetRTT.objects.create(asset=other_asset, rtt=10)
 
         url = reverse('asset_command_set', kwargs={'asset_id': other_asset.pk})
-        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        response = self.client.post(
+            url,
+            self._command_payload(
+                'TERM', operation_id=operation_id,
+                confirmation_token=token,
+            ),
+        )
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
         self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
@@ -299,10 +487,16 @@ class AssetAPITest(TestCase):
     def test_asset_command_set_rejects_confirmation_for_other_command(self):
         """A DISARM confirmation cannot authorize TERM."""
         self.client.force_login(self.user)
-        token = self._issue_confirmation('DISARM')
+        token, operation_id = self._issue_confirmation('DISARM')
 
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
-        response = self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+        response = self.client.post(
+            url,
+            self._command_payload(
+                'TERM', operation_id=operation_id,
+                confirmation_token=token,
+            ),
+        )
         self.assertEqual(response.status_code, 400)
         self.assertFalse(AssetCommand.objects.exists())
         self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
@@ -310,12 +504,18 @@ class AssetAPITest(TestCase):
     def test_asset_command_and_confirmation_consumption_are_atomic(self):
         """A failure while consuming evidence rolls back the queued command."""
         self.client.force_login(self.user)
-        token = self._issue_confirmation('TERM')
+        token, operation_id = self._issue_confirmation('TERM')
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
         with patch.object(AssetCommandConfirmation, 'delete', side_effect=IntegrityError):
             with self.assertRaises(IntegrityError):
-                self.client.post(url, {'command': 'TERM', 'confirmation_token': token})
+                self.client.post(
+                    url,
+                    self._command_payload(
+                        'TERM', operation_id=operation_id,
+                        confirmation_token=token,
+                    ),
+                )
 
         self.assertFalse(AssetCommand.objects.exists())
         self.assertTrue(AssetCommandConfirmation.objects.filter(token=token).exists())
@@ -326,6 +526,7 @@ class AssetAPITest(TestCase):
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
         response = self.client.post(url, {
             'command': 'GOTO',
+            'operation_id': str(uuid.uuid4()),
             'latitude': -43.0,
             'longitude': 172.0
         })
@@ -389,9 +590,10 @@ class AssetAPITest(TestCase):
                 self.assertEqual(response.content.decode(), expected_error)
                 self.assertFalse(AssetCommand.objects.exists())
 
-        token = self._issue_confirmation('TERM')
+        token, operation_id = self._issue_confirmation('TERM')
         response = self.client.post(url, {
             'command': 'TERM',
+            'operation_id': str(operation_id),
             'confirmation_token': token,
             'altitude': 100,
         })
@@ -406,21 +608,21 @@ class AssetAPITest(TestCase):
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        response = self.client.post(url, {'command': 'ALT', 'altitude': 1001})
+        response = self.client.post(url, self._command_payload('ALT', altitude=1001))
         self.assertEqual(response.status_code, 400)
 
         # AssetCommand.ALTITUDE_MAX_FT is the shared ceiling with the frontend's
         # max="999" input; 1000 must be rejected so the two layers cannot drift.
-        response = self.client.post(url, {'command': 'ALT', 'altitude': 1000})
+        response = self.client.post(url, self._command_payload('ALT', altitude=1000))
         self.assertEqual(response.status_code, 400)
 
-        response = self.client.post(url, {'command': 'ALT', 'altitude': 999})
+        response = self.client.post(url, self._command_payload('ALT', altitude=999))
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.post(url, {'command': 'ALT', 'altitude': -1})
+        response = self.client.post(url, self._command_payload('ALT', altitude=-1))
         self.assertEqual(response.status_code, 400)
 
-        response = self.client.post(url, {'command': 'ALT', 'altitude': 'high'})
+        response = self.client.post(url, self._command_payload('ALT', altitude='high'))
         self.assertEqual(response.status_code, 400)
 
     @satisfies('TC-WEB-012')
@@ -431,6 +633,7 @@ class AssetAPITest(TestCase):
 
         response = self.client.post(url, {
             'command': 'GOTO',
+            'operation_id': str(uuid.uuid4()),
             'latitude': 'invalid',
             'longitude': 172.0
         })
@@ -443,13 +646,13 @@ class AssetAPITest(TestCase):
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        response = self.client.post(url, {'command': 'GOTO', 'latitude': 91.0, 'longitude': 172.0})
+        response = self.client.post(url, self._command_payload('GOTO', latitude=91.0, longitude=172.0))
         self.assertEqual(response.status_code, 400)
 
-        response = self.client.post(url, {'command': 'GOTO', 'latitude': -43.0, 'longitude': 181.0})
+        response = self.client.post(url, self._command_payload('GOTO', latitude=-43.0, longitude=181.0))
         self.assertEqual(response.status_code, 400)
 
-        response = self.client.post(url, {'command': 'GOTO', 'latitude': -43.0, 'longitude': 172.0})
+        response = self.client.post(url, self._command_payload('GOTO', latitude=-43.0, longitude=172.0))
         self.assertEqual(response.status_code, 200)
 
     def test_asset_command_set_missing_params(self):
@@ -457,10 +660,10 @@ class AssetAPITest(TestCase):
         self.client.force_login(self.user)
         url = reverse('asset_command_set', kwargs={'asset_id': self.asset.pk})
 
-        response = self.client.post(url, {'command': 'GOTO', 'latitude': -43.0})
+        response = self.client.post(url, self._command_payload('GOTO', latitude=-43.0))
         self.assertEqual(response.status_code, 400)
 
-        response = self.client.post(url, {'command': 'ALT'})
+        response = self.client.post(url, self._command_payload('ALT'))
         self.assertEqual(response.status_code, 400)
 
     def test_all_status_data_includes_asset(self):

--- a/assets/views.py
+++ b/assets/views.py
@@ -2,6 +2,8 @@
 Views for Assets
 """
 
+import logging
+import uuid
 from datetime import timedelta
 
 from django.contrib.gis.geos import Point
@@ -20,6 +22,7 @@ from .models import Asset, AssetCommand, AssetCommandConfirmation, AssetPosition
 RTT_SAMPLE_LIMIT = 15
 COMMAND_CONFIRMATION_TTL = timedelta(seconds=60)
 ASSET_CONNECTION_TIMEOUT = timedelta(seconds=60)
+LOGGER = logging.getLogger('fss.security')
 
 # How far back the RTT window-function query below looks. Bounds the scan to
 # a fixed recent window instead of the fleet's entire history, while staying
@@ -311,7 +314,7 @@ def bulk_asset_status_data(assets):
 
 
 @login_required_api
-def asset_command_confirm(request, asset_id):
+def asset_command_confirm(request, asset_id):  # pylint: disable=too-many-return-statements
     """
     Issue short-lived, single-use evidence for a destructive command.
     """
@@ -322,15 +325,52 @@ def asset_command_confirm(request, asset_id):
     command = request.POST.get('command')
     if command not in AssetCommand.DESTRUCTIVE_COMMANDS:
         return HttpResponseBadRequest("Invalid destructive command")
+    unexpected_parameters = set(request.POST) - {'command', 'operation_id'}
+    if unexpected_parameters:
+        return HttpResponseBadRequest(
+            f"Unexpected parameter(s): {', '.join(sorted(unexpected_parameters))}"
+        )
+    operation_id = _parse_operation_id(request.POST.get('operation_id'))
+    if operation_id is None:
+        return HttpResponseBadRequest("Valid operation_id required")
+
+    # SECURITY-01 must add its destructive-command permission check here,
+    # before either revealing an existing operation or issuing evidence.
+    existing_command = AssetCommand.objects.filter(operation_id=operation_id).first()
+    if existing_command is not None:
+        requested = AssetCommand(
+            asset=asset,
+            command=command,
+            operation_id=operation_id,
+            issued_by=request.user,
+        )
+        if not _same_command_operation(existing_command, requested):
+            return _operation_conflict_response(existing_command, requested)
+        return JsonResponse({'operation_committed': True})
 
     now = timezone.now()
     AssetCommandConfirmation.objects.filter(expires_at__lte=now).delete()
+    existing_confirmation = AssetCommandConfirmation.objects.filter(
+        operation_id=operation_id,
+        user=request.user,
+        asset=asset,
+        command=command,
+        expires_at__gt=now,
+    ).first()
+    if existing_confirmation is not None:
+        return _confirmation_response(existing_confirmation)
     confirmation = AssetCommandConfirmation.objects.create(
+        operation_id=operation_id,
         user=request.user,
         asset=asset,
         command=command,
         expires_at=now + COMMAND_CONFIRMATION_TTL,
     )
+    return _confirmation_response(confirmation)
+
+
+def _confirmation_response(confirmation):
+    """Format destructive confirmation evidence consistently."""
     return JsonResponse({
         'confirmation_token': str(confirmation.token),
         'expires_at': confirmation.expires_at,
@@ -340,23 +380,104 @@ def asset_command_confirm(request, asset_id):
 def _queue_destructive_command(asset_command, user, confirmation_token):
     """
     Consume matching confirmation evidence and queue its command atomically.
+
+    Return the queued command, whether it was newly created, and whether valid
+    confirmation evidence was available. A unique-operation race resolves to
+    the winning row without consuming a second confirmation.
     """
     try:
         with transaction.atomic():
             confirmation = AssetCommandConfirmation.objects.select_for_update().filter(
                 token=confirmation_token,
+                operation_id=asset_command.operation_id,
                 user=user,
                 asset=asset_command.asset,
                 command=asset_command.command,
                 expires_at__gt=timezone.now(),
             ).first()
             if confirmation is None:
-                return False
-            asset_command.save()
+                existing = AssetCommand.objects.filter(
+                    operation_id=asset_command.operation_id,
+                ).first()
+                return existing, False, existing is not None
+            try:
+                # The savepoint keeps the outer transaction usable if another
+                # request inserts the operation after the initial lookup.
+                with transaction.atomic():
+                    asset_command.save()
+            except IntegrityError:
+                existing = AssetCommand.objects.get(
+                    operation_id=asset_command.operation_id,
+                )
+                return existing, False, True
+            AssetCommandConfirmation.objects.filter(
+                operation_id=asset_command.operation_id,
+                user=user,
+                asset=asset_command.asset,
+                command=asset_command.command,
+            ).exclude(pk=confirmation.pk).delete()
             confirmation.delete()
     except (TypeError, ValidationError, ValueError):
-        return False
-    return True
+        return None, False, False
+    return asset_command, True, True
+
+
+def _queue_routine_command(asset_command):
+    """Insert a routine command or resolve a concurrent operation insert."""
+    try:
+        with transaction.atomic():
+            asset_command.save()
+    except IntegrityError:
+        existing = AssetCommand.objects.filter(
+            operation_id=asset_command.operation_id,
+        ).first()
+        if existing is None:
+            raise
+        return existing, False
+    return asset_command, True
+
+
+def _parse_operation_id(value):
+    """Return a UUID for a valid operation identifier, otherwise None."""
+    try:
+        return uuid.UUID(value)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _same_position(left, right):
+    """Compare optional command points without relying on database SRIDs."""
+    if left is None or right is None:
+        return left is None and right is None
+    return left.x == right.x and left.y == right.y
+
+
+def _same_command_operation(existing, requested):
+    """Return whether two rows describe the same logical operator action."""
+    return all((
+        existing.issued_by_id == requested.issued_by_id,
+        existing.asset_id == requested.asset_id,
+        existing.command == requested.command,
+        _same_position(existing.position, requested.position),
+        existing.altitude == requested.altitude,
+    ))
+
+
+def _operation_conflict_response(existing, requested):
+    """Log and reject reuse of an operation identifier for different input."""
+    LOGGER.warning(
+        "Command operation ID conflict operation_id=%s existing_user_id=%s "
+        "requested_user_id=%s existing_asset_id=%s requested_asset_id=%s "
+        "existing_command=%s requested_command=%s",
+        requested.operation_id,
+        existing.issued_by_id,
+        requested.issued_by_id,
+        existing.asset_id,
+        requested.asset_id,
+        existing.command,
+        requested.command,
+    )
+    return HttpResponse("Operation ID conflicts with an existing command", status=409)
 
 
 def _command_parameter_error(parameters, command):
@@ -370,7 +491,7 @@ def _command_parameter_error(parameters, command):
 
 
 @login_required_api
-def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-statements
+def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-statements,too-many-locals,too-many-branches
     """
     Set the command for a given asset
     """
@@ -382,6 +503,9 @@ def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-sta
         parameter_error = _command_parameter_error(request.POST, command)
         if parameter_error is not None:
             return HttpResponseBadRequest(parameter_error)
+        operation_id = _parse_operation_id(request.POST.get('operation_id'))
+        if operation_id is None:
+            return HttpResponseBadRequest("Valid operation_id required")
         if command in AssetCommand.REQUIRES_POSITION:
             latitude = request.POST.get('latitude')
             longitude = request.POST.get('longitude')
@@ -400,24 +524,41 @@ def asset_command_set(request, asset_id):  # pylint: disable=too-many-return-sta
                     raise ValueError
             except (ValueError, TypeError):
                 return HttpResponseBadRequest('Invalid Altitude')
-        if not asset_has_live_connection(asset):
-            return HttpResponse(
-                "Asset is disconnected: no recent RTT response",
-                status=409,
-            )
         # @login_required_api guarantees an authenticated user here; guard
         # anyway so that decorator changing can't try to assign an AnonymousUser
         # to the FK. None keeps the command row, just without an attributed user.
         issued_by = request.user if request.user.is_authenticated else None
         asset_command = AssetCommand(asset=asset, command=command,
                                      position=point, altitude=altitude,
-                                     issued_by=issued_by)
+                                     issued_by=issued_by,
+                                     operation_id=operation_id)
+        # SECURITY-01 must add its command-class permission check here, after
+        # parsing the requested command but before this operation lookup.
+        existing_command = AssetCommand.objects.filter(operation_id=operation_id).first()
+        if existing_command is not None:
+            if not _same_command_operation(existing_command, asset_command):
+                return _operation_conflict_response(existing_command, asset_command)
+            return HttpResponse("Queued")
+        if not asset_has_live_connection(asset):
+            return HttpResponse(
+                "Asset is disconnected: no recent RTT response",
+                status=409,
+            )
         if command in AssetCommand.DESTRUCTIVE_COMMANDS:
             confirmation_token = request.POST.get('confirmation_token')
-            if not _queue_destructive_command(asset_command, request.user, confirmation_token):
+            queued_command, _created, confirmed = _queue_destructive_command(
+                asset_command,
+                request.user,
+                confirmation_token,
+            )
+            if not confirmed:
                 return HttpResponseBadRequest("Valid confirmation required")
+            if not _same_command_operation(queued_command, asset_command):
+                return _operation_conflict_response(queued_command, asset_command)
         else:
-            asset_command.save()
+            queued_command, _created = _queue_routine_command(asset_command)
+            if not _same_command_operation(queued_command, asset_command):
+                return _operation_conflict_response(queued_command, asset_command)
         return HttpResponse("Queued")
     return HttpResponseBadRequest("Only POST is supported")
 


### PR DESCRIPTION
## Description

Retries and concurrent requests must resolve to one safety-critical command rather than enqueueing duplicates. Require operation UUIDs, bind destructive evidence to them, replay identical requests before liveness or confirmation checks, and reject conflicting reuse with an audit log.

## Summary by Sourcery

Enforce idempotent asset command operations by introducing operation UUIDs, binding destructive confirmations to them, and reconciling retries and concurrent submissions against existing commands.

New Features:
- Require an operation_id UUID on all web asset command and destructive confirmation requests.
- Allow destructive confirmation requests to reuse live evidence for the same operation and detect already-committed operations.
- Provide structured responses indicating when a destructive operation has already been committed.

Enhancements:
- Add operation-level conflict detection to reject reuse of a UUID for different commands, parameters, assets, or users, with security logging.
- Centralize command queuing into helpers that handle atomic insertion, confirmation consumption, and resolution of concurrent operation races.
- Extend command parameter validation to include operation_id and unexpected parameter checks for confirmation requests.

Tests:
- Add comprehensive tests covering operation_id requirements, idempotent command replay, operation payload and identity conflicts, and confirmation reuse semantics.
- Update existing Asset API tests to include operation_id in command payloads and to verify operation binding for confirmations and queued commands.