### PR TITLE
Retry command operations safely across peers

### DIFF
--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AssetState, createAsset, mergeServerAssets, sendAssetCommand } from './asset'
+import { AssetState, CommandDispatchError, createAsset, mergeServerAssets, sendAssetCommand } from './asset'
 import { ServerState, createServer } from './server'
 import { AssetStatus } from './server'
 
@@ -49,6 +49,7 @@ describe('sendAssetCommand', () => {
     expect(options.headers['X-CSRFToken']).toBe('csrf-123')
     const body = options.body as URLSearchParams
     expect(body.get('command')).toBe('RTL')
+    expect(body.get('operation_id')).toMatch(/^[0-9a-f-]{36}$/)
   })
 
   it('serialises GOTO coordinates into the request body', async () => {
@@ -89,6 +90,7 @@ describe('sendAssetCommand', () => {
     const commandBody = fetchMock.mock.calls[1][1].body as URLSearchParams
     expect(commandBody.get('command')).toBe('TERM')
     expect(commandBody.get('confirmation_token')).toBe('confirm-123')
+    expect(commandBody.get('operation_id')).toBe((fetchMock.mock.calls[0][1].body as URLSearchParams).get('operation_id'))
   })
 
   it('uses a separate confirmation token for each server target', async () => {
@@ -146,6 +148,22 @@ describe('sendAssetCommand', () => {
     const urls = fetchMock.mock.calls.map((c) => c[0])
     expect(urls).toContain('https://alpha.example/assets/1/command/set/')
     expect(urls).toContain('https://beta.example/assets/2/command/set/')
+    const operationIds = fetchMock.mock.calls.map((call) => (call[1].body as URLSearchParams).get('operation_id'))
+    expect(new Set(operationIds).size).toBe(1)
+  })
+
+  it('uses a new operation ID for a separate operator action', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1 }])
+
+    await sendAssetCommand(servers, asset, { command: 'RTL' })
+    await sendAssetCommand(servers, asset, { command: 'RTL' })
+
+    const operationIds = fetchMock.mock.calls.map((call) => (call[1].body as URLSearchParams).get('operation_id'))
+    expect(operationIds[0]).not.toBe(operationIds[1])
   })
 
   it('skips servers that are not in the known-servers map', async () => {
@@ -204,6 +222,141 @@ describe('sendAssetCommand', () => {
     ])
 
     await expect(sendAssetCommand(servers, asset, { command: 'RTL' })).rejects.toThrow(/queued on 1 of 2 server\(s\).*beta: 500 Server Error/s)
+  })
+
+  it('retries only unresolved peers with the original operation ID', async () => {
+    let betaAttempts = 0
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('beta') && ++betaAttempts === 1) {
+        return { ok: false, status: 500, statusText: 'Server Error' }
+      }
+      return { ok: true, status: 200 }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha'), beta: makeServer('beta') }
+    const asset = makeAsset('Drone', [
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'beta', assetPk: 2 }
+    ])
+
+    let failure: CommandDispatchError | undefined
+    try {
+      await sendAssetCommand(servers, asset, { command: 'RTL' })
+    } catch (error) {
+      failure = error as CommandDispatchError
+    }
+    expect(failure).toBeInstanceOf(CommandDispatchError)
+    await failure!.retry()
+
+    const alphaRequests = fetchMock.mock.calls.filter((call) => (call[0] as string).includes('alpha'))
+    const betaRequests = fetchMock.mock.calls.filter((call) => (call[0] as string).includes('beta'))
+    expect(alphaRequests).toHaveLength(1)
+    expect(betaRequests).toHaveLength(2)
+    const operationIds = fetchMock.mock.calls.map((call) => (call[1].body as URLSearchParams).get('operation_id'))
+    expect(new Set(operationIds).size).toBe(1)
+  })
+
+  it('retries a previously skipped peer without resending to a successful peer', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha'), beta: makeServer('beta') }
+    const asset = makeAsset('Drone', [
+      { serverKey: 'alpha', assetPk: 1 },
+      { serverKey: 'beta', assetPk: 2, connected: false }
+    ])
+
+    let failure: CommandDispatchError | undefined
+    try {
+      await sendAssetCommand(servers, asset, { command: 'RTL' })
+    } catch (error) {
+      failure = error as CommandDispatchError
+    }
+    await failure!.retry()
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual(['https://alpha.example/assets/1/command/set/', 'https://beta.example/assets/2/command/set/'])
+  })
+
+  it('preserves destructive confirmation evidence when retrying an uncertain peer', async () => {
+    let setAttempts = 0
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith('/command/confirm/')) {
+        return { ok: true, status: 200, json: async () => ({ confirmation_token: 'confirm-123' }) }
+      }
+      setAttempts += 1
+      return setAttempts === 1 ? { ok: false, status: 500, statusText: 'Server Error' } : { ok: true, status: 200 }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1 }])
+
+    let failure: CommandDispatchError | undefined
+    try {
+      await sendAssetCommand(servers, asset, { command: 'TERM' })
+    } catch (error) {
+      failure = error as CommandDispatchError
+    }
+    await failure!.retry()
+
+    const confirmRequests = fetchMock.mock.calls.filter((call) => (call[0] as string).endsWith('/command/confirm/'))
+    const setRequests = fetchMock.mock.calls.filter((call) => (call[0] as string).endsWith('/command/set/'))
+    expect(confirmRequests).toHaveLength(1)
+    expect(setRequests).toHaveLength(2)
+    expect((setRequests[0][1].body as URLSearchParams).get('confirmation_token')).toBe('confirm-123')
+    expect((setRequests[1][1].body as URLSearchParams).get('confirmation_token')).toBe('confirm-123')
+  })
+
+  it('refreshes expired destructive evidence against the same operation on retry', async () => {
+    let confirmAttempts = 0
+    let setAttempts = 0
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith('/command/confirm/')) {
+        confirmAttempts += 1
+        return { ok: true, status: 200, json: async () => ({ confirmation_token: `confirm-${confirmAttempts}` }) }
+      }
+      setAttempts += 1
+      if (setAttempts === 1) return { ok: false, status: 500, statusText: 'Server Error' }
+      if (setAttempts === 2) return { ok: false, status: 400, text: async () => 'Valid confirmation required' }
+      return { ok: true, status: 200 }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1 }])
+
+    let failure: CommandDispatchError | undefined
+    try {
+      await sendAssetCommand(servers, asset, { command: 'DISARM' })
+    } catch (error) {
+      failure = error as CommandDispatchError
+    }
+    await failure!.retry()
+
+    const requests = fetchMock.mock.calls.map((call) => ({
+      url: call[0] as string,
+      body: call[1].body as URLSearchParams
+    }))
+    const operationIds = requests.map(({ body }) => body.get('operation_id'))
+    expect(new Set(operationIds).size).toBe(1)
+    expect(requests.filter(({ url }) => url.endsWith('/command/confirm/'))).toHaveLength(2)
+    expect(requests[requests.length - 1].body.get('confirmation_token')).toBe('confirm-2')
+  })
+
+  it('surfaces an operation conflict instead of calling it a disconnect', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      text: async () => 'Operation ID conflicts with an existing command'
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const servers = { alpha: makeServer('alpha') }
+    const asset = makeAsset('Drone', [{ serverKey: 'alpha', assetPk: 1 }])
+
+    await expect(sendAssetCommand(servers, asset, { command: 'RTL' })).rejects.toThrow(/Operation ID conflicts with an existing command/)
   })
 
   it('surfaces a clear message when a server returns 403', async () => {

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -78,62 +78,171 @@ export const assetCommandAvailability = (knownServers: Record<string, ServerStat
   }
 }
 
-export const sendAssetCommand = async (knownServers: Record<string, ServerState>, asset: AssetState, data: CommandPayload) => {
-  const entries: [string, string][] = Object.entries(data).map(([k, v]) => [k, String(v)])
-  const resolvedTargets = resolveAssetTargets(knownServers, asset)
-  const targets = resolvedTargets.filter((target) => !target.blockedReason)
-  const skipped = resolvedTargets.filter((target) => target.blockedReason)
-  if (targets.length === 0) {
-    const reasons = skipped.length > 0 ? skipped.map((target) => `${target.assetServer.serverName}: ${target.blockedReason}`).join(', ') : 'no known management server'
-    throw new Error(`Command not sent — ${asset.name} has no commandable server (${reasons})`)
+export interface CommandSubmissionGuard {
+  acquire(): boolean
+  release(): void
+}
+
+export class CommandDispatchError extends Error {
+  constructor(
+    message: string,
+    readonly retry: () => Promise<void>
+  ) {
+    super(message)
+    this.name = 'CommandDispatchError'
   }
-  const results = await Promise.allSettled(
-    targets.map(async ({ assetServer, server }) => {
-      const post = (path: string, bodyEntries: [string, string][]) =>
-        fetch(getAssetServerURL(server, assetServer, path), {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-            'X-CSRFToken': server.csrfToken ?? ''
-          },
-          body: new URLSearchParams(bodyEntries)
-        }).then((response) => {
-          if (response.status === 403) throw new Error('not authenticated — please refresh and log in')
-          if (response.status === 409) throw new Error('asset disconnected — no recent RTT response')
-          if (!response.ok) throw new Error(`${response.status} ${response.statusText}`)
-          return response
-        })
+}
 
-      let commandEntries = entries
-      if (isDestructiveCommand(data.command)) {
-        const confirmationResponse = await post('command/confirm/', [['command', data.command]])
-        const confirmation = (await confirmationResponse.json()) as { confirmation_token?: unknown }
-        if (typeof confirmation.confirmation_token !== 'string') {
-          throw new Error('server returned an invalid confirmation token')
-        }
-        commandEntries = [...entries, ['confirmation_token', confirmation.confirmation_token]]
-      }
-      await post('command/set/', commandEntries)
+class CommandRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly responseBody: string,
+    message: string
+  ) {
+    super(message)
+    this.name = 'CommandRequestError'
+  }
+}
+
+class SkippedTargetError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SkippedTargetError'
+  }
+}
+
+interface CommandTargetState {
+  target: AssetTarget
+  confirmationToken?: string
+}
+
+const commandFailureMessage = (response: Response, responseBody: string): string => {
+  if (response.status === 403) return 'not authenticated — please refresh and log in'
+  if (response.status === 409 && responseBody.startsWith('Asset is disconnected')) return 'asset disconnected — no recent RTT response'
+  if (responseBody) return responseBody
+  return `${response.status} ${response.statusText}`.trim()
+}
+
+export const sendAssetCommand = async (knownServers: Record<string, ServerState>, asset: AssetState, data: CommandPayload, submissionGuard?: CommandSubmissionGuard) => {
+  const operationId = crypto.randomUUID()
+  const entries: [string, string][] = [...Object.entries(data).map(([k, v]) => [k, String(v)] as [string, string]), ['operation_id', operationId]]
+  const resolvedTargets = resolveAssetTargets(knownServers, asset)
+  if (resolvedTargets.length === 0) {
+    throw new Error(`Command not sent — ${asset.name} has no commandable server (no known management server)`)
+  }
+
+  let unresolvedTargets: CommandTargetState[] = resolvedTargets.map((target) => ({ target }))
+  let activeDispatch: Promise<void> | undefined
+
+  const post = async (target: AssetTarget, path: string, bodyEntries: [string, string][]) => {
+    const response = await fetch(getAssetServerURL(target.server, target.assetServer, path), {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'X-CSRFToken': target.server.csrfToken ?? ''
+      },
+      body: new URLSearchParams(bodyEntries)
     })
-  )
+    if (!response.ok) {
+      const responseBody = typeof response.text === 'function' ? await response.text() : ''
+      throw new CommandRequestError(response.status, responseBody, commandFailureMessage(response, responseBody))
+    }
+    return response
+  }
 
-  const failures = results.map((result, i) => ({ result, serverName: targets[i].assetServer.serverName })).filter(({ result }) => result.status === 'rejected')
+  const prepareDestructiveCommand = async (state: CommandTargetState): Promise<boolean> => {
+    const response = await post(state.target, 'command/confirm/', [
+      ['command', data.command],
+      ['operation_id', operationId]
+    ])
+    const confirmation = (await response.json()) as { confirmation_token?: unknown; operation_committed?: unknown }
+    if (confirmation.operation_committed === true) {
+      state.confirmationToken = undefined
+      return true
+    }
+    if (typeof confirmation.confirmation_token !== 'string') {
+      throw new Error('server returned an invalid confirmation token')
+    }
+    state.confirmationToken = confirmation.confirmation_token
+    return false
+  }
 
-  if (failures.length > 0 || skipped.length > 0) {
-    const failureMessages = failures
-      .map(({ result, serverName }) => {
+  const dispatchTarget = async (state: CommandTargetState) => {
+    if (!isDestructiveCommand(data.command)) {
+      await post(state.target, 'command/set/', entries)
+      return
+    }
+
+    if (!state.confirmationToken) {
+      const alreadyCommitted = await prepareDestructiveCommand(state)
+      if (alreadyCommitted) {
+        await post(state.target, 'command/set/', entries)
+        return
+      }
+    }
+
+    try {
+      await post(state.target, 'command/set/', [...entries, ['confirmation_token', state.confirmationToken!]])
+    } catch (error) {
+      const confirmationExpired = error instanceof CommandRequestError && error.status === 400 && error.responseBody === 'Valid confirmation required'
+      if (!confirmationExpired) throw error
+      state.confirmationToken = undefined
+      const alreadyCommitted = await prepareDestructiveCommand(state)
+      if (alreadyCommitted) {
+        await post(state.target, 'command/set/', entries)
+      } else {
+        await post(state.target, 'command/set/', [...entries, ['confirmation_token', state.confirmationToken!]])
+      }
+    }
+  }
+
+  const dispatchUnresolved = async (initial: boolean) => {
+    const attemptedTargets = unresolvedTargets
+    const results = await Promise.allSettled(
+      attemptedTargets.map(async (state) => {
+        if (initial && state.target.blockedReason) {
+          throw new SkippedTargetError(state.target.blockedReason)
+        }
+        await dispatchTarget(state)
+      })
+    )
+    const failures = results.map((result, index) => ({ result, state: attemptedTargets[index] })).filter(({ result }) => result.status === 'rejected')
+    unresolvedTargets = failures.map(({ state }) => state)
+
+    if (failures.length === 0) return
+
+    const skipped = failures.filter(({ result }) => (result as PromiseRejectedResult).reason instanceof SkippedTargetError)
+    const attemptedFailures = failures.filter(({ result }) => !((result as PromiseRejectedResult).reason instanceof SkippedTargetError))
+    const failureMessages = attemptedFailures
+      .map(({ result, state }) => {
         const reason = (result as PromiseRejectedResult).reason
         const msg = reason instanceof Error ? reason.message : String(reason)
-        return `${serverName}: ${msg}`
+        return `${state.target.assetServer.serverName}: ${msg}`
       })
       .join(', ')
-    const successCount = targets.length - failures.length
+    const successCount = resolvedTargets.length - failures.length
+    if (successCount === 0 && attemptedFailures.length === 0) {
+      const reasons = skipped.map(({ state }) => `${state.target.assetServer.serverName}: ${state.target.blockedReason}`).join(', ')
+      throw new CommandDispatchError(`Command not sent — ${asset.name} has no commandable server (${reasons})`, () => dispatch(false))
+    }
     const prefix = successCount > 0 ? `Command was queued on ${successCount} of ${resolvedTargets.length} server(s) — aircraft may already be affected. ` : ''
-    const skippedMessage = skipped.length > 0 ? `Skipped: ${skipped.map((target) => `${target.assetServer.serverName}: ${target.blockedReason}`).join(', ')}. ` : ''
-    const failedMessage = failures.length > 0 ? `Failed on: ${failureMessages}` : ''
-    throw new Error(`${prefix}${skippedMessage}${failedMessage}`.trim())
+    const skippedMessage = skipped.length > 0 ? `Skipped: ${skipped.map(({ state }) => `${state.target.assetServer.serverName}: ${state.target.blockedReason}`).join(', ')}. ` : ''
+    const failedMessage = attemptedFailures.length > 0 ? `Failed on: ${failureMessages}` : ''
+    throw new CommandDispatchError(`${prefix}${skippedMessage}${failedMessage}`.trim(), () => dispatch(false))
   }
+
+  const dispatch = (initial: boolean): Promise<void> => {
+    if (activeDispatch) return activeDispatch
+    if (submissionGuard && !submissionGuard.acquire()) return Promise.resolve()
+    activeDispatch = dispatchUnresolved(initial).finally(() => {
+      activeDispatch = undefined
+      submissionGuard?.release()
+    })
+    return activeDispatch
+  }
+
+  return dispatch(true)
 }
 
 export const assetPositionMostRecent = (asset: AssetState): AssetPositionData | undefined => {
@@ -213,8 +322,8 @@ export interface AssetController {
   positionMostRecent(): AssetPositionData | undefined
 }
 
-export const createAssetController = (knownServers: Record<string, ServerState>, asset: AssetState): AssetController => {
-  const send = (data: CommandPayload) => sendAssetCommand(knownServers, asset, data)
+export const createAssetController = (knownServers: Record<string, ServerState>, asset: AssetState, submissionGuard?: CommandSubmissionGuard): AssetController => {
+  const send = (data: CommandPayload) => sendAssetCommand(knownServers, asset, data, submissionGuard)
   return {
     name: asset.name,
     RTL: () => send({ command: 'RTL' }),

--- a/frontend/fss-main-page.test.tsx
+++ b/frontend/fss-main-page.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { mergeServerAssets } from './asset'
-import { FSSAsset, FSSServerBar } from './fss-main-page'
+import { FSSAsset, FSSMainPage, FSSServerBar } from './fss-main-page'
 import { AssetStatus, ServerState, createServer, serverConnectFailed } from './server'
 
 const SERVER_KEY = 'https://alpha.example'
@@ -23,7 +23,10 @@ const cannedAssetStatus = (connected: boolean): AssetStatus => ({
   connected
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe('disconnected asset command controls', () => {
   it('disables every command control when canned status reports no live connection', () => {
@@ -47,6 +50,34 @@ describe('disconnected asset command controls', () => {
     expect(screen.queryByRole('status')).toBeNull()
     expect((screen.getByRole('button', { name: 'RTL' }) as HTMLButtonElement).disabled).toBe(false)
   })
+
+  it('blocks rapid duplicate actions and disables every command control while submitting', async () => {
+    let resolveRequest: ((response: { ok: boolean; status: number }) => void) | undefined
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const servers = { [SERVER_KEY]: makeServer() }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [cannedAssetStatus(true)], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'RTL' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hold' }))
+
+    await waitFor(() => {
+      for (const name of ['RTL', 'Hold', 'Altitude', 'Goto', 'Continue', 'Manual', 'DisArm', 'Terminate']) {
+        expect((screen.getByRole('button', { name }) as HTMLButtonElement).disabled).toBe(true)
+      }
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveRequest!({ ok: true, status: 200 })
+    await waitFor(() => expect((screen.getByRole('button', { name: 'RTL' }) as HTMLButtonElement).disabled).toBe(false))
+  })
 })
 
 describe('asset command rendering', () => {
@@ -68,6 +99,43 @@ describe('asset command rendering', () => {
     render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
 
     expect(screen.getByText('Goto Position 0 0.000 N, 0 0.000 E')).toBeTruthy()
+  })
+})
+
+describe('command retry alert', () => {
+  it('offers an explicit retry and clears the failure after that peer succeeds', async () => {
+    let commandAttempts = 0
+    const fetchMock = vi.fn().mockImplementation(async (_url: string, options?: RequestInit) => {
+      if (options?.method === 'POST') {
+        commandAttempts += 1
+        return commandAttempts === 1 ? { ok: false, status: 500, statusText: 'Server Error' } : { ok: true, status: 200 }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          currentUser: 'pilot',
+          csrfToken: 'csrf-123',
+          server_now: SERVER_NOW,
+          servers: [],
+          assets: [cannedAssetStatus(true)]
+        })
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FSSMainPage />)
+    fireEvent.click(await screen.findByRole('button', { name: 'RTL' }))
+
+    const retry = await screen.findByRole('button', { name: 'Retry failed servers' })
+    expect(screen.getByText('Command Failure:').closest('[role="alert"]')!.textContent).toContain('Failed on: direct: 500 Server Error')
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Retry failed servers' })).toBeNull())
+    expect(commandAttempts).toBe(2)
+    const commandRequests = fetchMock.mock.calls.filter((call) => call[1]?.method === 'POST')
+    const operationIds = commandRequests.map((call) => (call[1]!.body as URLSearchParams).get('operation_id'))
+    expect(new Set(operationIds).size).toBe(1)
   })
 })
 

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -1,5 +1,14 @@
 import { type Axis, degreesToDM, DMToDegrees } from '@canterbury-air-patrol/deg-converter'
-import { AssetState, AssetServerState, AssetController, assetCommandAvailability, createAssetController, mergeServerAssets } from './asset'
+import {
+  AssetState,
+  AssetServerState,
+  AssetController,
+  CommandDispatchError,
+  CommandSubmissionGuard,
+  assetCommandAvailability,
+  createAssetController,
+  mergeServerAssets
+} from './asset'
 import { ServerState, canonicalServerOrigin, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, mergeServerPollResult } from './server'
 import {
   assetPositionTimeWarn,
@@ -43,7 +52,17 @@ L.Icon.Default.prototype.options.iconUrl = markerIcon
 L.Icon.Default.prototype.options.iconRetinaUrl = markerIcon2x
 L.Icon.Default.prototype.options.shadowUrl = markerIconShadow
 
-const ErrorContext = React.createContext<(msg: string | null) => void>(() => {})
+interface CommandFailure {
+  message: string
+  retry?: () => Promise<void>
+}
+
+const commandFailure = (error: unknown): CommandFailure => ({
+  message: error instanceof Error ? error.message : String(error),
+  retry: error instanceof CommandDispatchError ? error.retry : undefined
+})
+
+const ErrorContext = React.createContext<(failure: CommandFailure | null) => void>(() => {})
 
 const useCommand = () => {
   const setLastError = useContext(ErrorContext)
@@ -52,7 +71,7 @@ const useCommand = () => {
       await Promise.resolve(fn())
       onClose?.()
     } catch (e) {
-      setLastError(e instanceof Error ? e.message : String(e))
+      setLastError(commandFailure(e))
     }
   }
 }
@@ -390,8 +409,26 @@ interface FSSAssetContainerProps {
 
 export function FSSAsset(props: FSSAssetContainerProps) {
   const { asset, knownServers, setSelected } = props
-  const controller = useMemo(() => createAssetController(knownServers, asset), [knownServers, asset])
+  const [commandInFlight, setCommandInFlight] = useState(false)
+  const commandInFlightRef = useRef(false)
+  const submissionGuard = useMemo<CommandSubmissionGuard>(
+    () => ({
+      acquire: () => {
+        if (commandInFlightRef.current) return false
+        commandInFlightRef.current = true
+        setCommandInFlight(true)
+        return true
+      },
+      release: () => {
+        commandInFlightRef.current = false
+        setCommandInFlight(false)
+      }
+    }),
+    []
+  )
+  const controller = useMemo(() => createAssetController(knownServers, asset, submissionGuard), [knownServers, asset, submissionGuard])
   const commandAvailability = useMemo(() => assetCommandAvailability(knownServers, asset), [knownServers, asset])
+  const controlsDisabled = commandInFlight || !commandAvailability.commandable
   return (
     <div className="asset">
       <div className="asset-label">{asset.name}</div>
@@ -400,7 +437,7 @@ export function FSSAsset(props: FSSAssetContainerProps) {
           <strong>Commands disabled:</strong> {commandAvailability.blockedReasons.join(', ')}
         </div>
       )}
-      <FSSAssetControls controller={controller} disabled={!commandAvailability.commandable} />
+      <FSSAssetControls controller={controller} disabled={controlsDisabled} />
       <FSSAssetStatus asset={asset} setSelected={setSelected} />
     </div>
   )
@@ -472,7 +509,8 @@ export const FSSMainPage: React.FC = () => {
     [canonicalServerOrigin(window.location.origin)]: createServer('direct', '127.0.0.1', 0, window.location.origin)
   })
   const [knownAssets, setKnownAssets] = useState<Record<string, AssetState>>({})
-  const [lastError, setLastError] = useState<string | null>(null)
+  const [lastError, setLastError] = useState<CommandFailure | null>(null)
+  const [retryingCommand, setRetryingCommand] = useState(false)
 
   // Latest-value refs for polling
   const knownServersRef = useRef(knownServers)
@@ -565,12 +603,30 @@ export const FSSMainPage: React.FC = () => {
     })
   }
 
+  const retryLastCommand = async () => {
+    if (!lastError?.retry || retryingCommand) return
+    setRetryingCommand(true)
+    try {
+      await lastError.retry()
+      setLastError(null)
+    } catch (error) {
+      setLastError(commandFailure(error))
+    } finally {
+      setRetryingCommand(false)
+    }
+  }
+
   return (
     <ErrorContext.Provider value={setLastError}>
       <div>
         {lastError && (
           <div className="alert alert-danger alert-dismissible fade show m-3" role="alert">
-            <strong>Command Failure:</strong> {lastError}
+            <strong>Command Failure:</strong> {lastError.message}
+            {lastError.retry && (
+              <button type="button" className="btn btn-danger ms-2" onClick={retryLastCommand} disabled={retryingCommand}>
+                Retry failed servers
+              </button>
+            )}
             <button type="button" className="btn-close" onClick={() => setLastError(null)} aria-label="Close"></button>
           </div>
         )}


### PR DESCRIPTION
## Description

Operators need one logical action to survive partial server failures without resending to peers that already succeeded. Preserve operation IDs and confirmation state, expose an unresolved-peer retry, and guard all controls for an asset while a submission is active.

## Summary by Sourcery

Add robust command submission and retry handling across asset servers, including operation IDs, partial failure retries, and UI guardrails during command dispatch.

New Features:
- Introduce per-command operation IDs to correlate submissions across asset servers and retries.
- Expose a retry mechanism for failed or skipped command targets while preserving prior successes.
- Surface command failures in the main page with an explicit "Retry failed servers" action.

Bug Fixes:
- Ensure destructive command confirmation conflicts and expired confirmations are reported accurately instead of as generic disconnects.

Enhancements:
- Refine command dispatch error reporting with structured errors and clearer user-facing messages.
- Guard asset command controls with a submission lock to prevent duplicate actions while a command is in flight.

Tests:
- Expand unit and UI tests to cover operation ID behavior, partial failure retries, destructive confirmation refresh, and command submission locking.