### PR TITLE
ops: persist the Compose database

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,8 @@ services:
       - /code/docker/prune-telemetry.sh
   db:
     image: postgis/postgis:18-3.6-alpine
+    volumes:
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_USER=${DB_USER:?Set DB_USER in .env}
       - POSTGRES_DB=${DB_NAME:?Set DB_NAME in .env}
@@ -61,3 +63,6 @@ services:
       test: ["CMD-SHELL", "pg_isready --username=\"$${POSTGRES_USER}\" --dbname=\"$${POSTGRES_DB}\""]
       timeout: 10s
       retries: 20
+
+volumes:
+  db-data:

--- a/docker/compose-smoke.py
+++ b/docker/compose-smoke.py
@@ -6,10 +6,15 @@ import json
 import os
 import sys
 import time
+import uuid
 from http.cookiejar import CookieJar
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import HTTPCookieProcessor, Request, build_opener
+
+
+SMOKE_ASSET_NAME = 'Compose Smoke Asset'
+SMOKE_OPERATION_ID = uuid.UUID('e3759a70-f1b8-4c3b-b26c-27cdb2b59751')
 
 
 def require(condition, message):
@@ -57,7 +62,71 @@ def verify_config(args):
     healthcheck = ' '.join(db_service['healthcheck']['test'])
     require('POSTGRES_USER' in healthcheck, 'database health check does not select POSTGRES_USER')
     require('POSTGRES_DB' in healthcheck, 'database health check does not select POSTGRES_DB')
+    database_volumes = db_service.get('volumes', [])
+    expected_volume = {
+        'type': 'volume',
+        'source': 'db-data',
+        'target': '/var/lib/postgresql',
+    }
+    require(
+        any(
+            all(volume.get(key) == value for key, value in expected_volume.items())
+            for volume in database_volumes
+        ),
+        'database does not mount db-data at the PostgreSQL 18 persistent root',
+    )
     print('Rendered Compose config passes database checks.')
+
+
+def setup_django():
+    """Initialize Django only for commands that inspect application data."""
+    repository_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.insert(0, repository_root)
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fss.settings')
+    import django  # pylint: disable=import-outside-toplevel
+    django.setup()
+
+
+def seed_audit_data(_args):
+    """Create stable application and audit rows for persistence tests."""
+    setup_django()
+    from django.contrib.auth import get_user_model  # pylint: disable=import-outside-toplevel
+    from assets.models import Asset, AssetCommand, AssetRTT  # pylint: disable=import-outside-toplevel
+
+    username = os.environ['DJANGO_SUPERUSER_USERNAME']
+    user = get_user_model().objects.get(username=username)
+    asset, _created = Asset.objects.get_or_create(name=SMOKE_ASSET_NAME)
+    AssetRTT.objects.get_or_create(asset=asset, rtt=25)
+    AssetCommand.objects.get_or_create(
+        operation_id=SMOKE_OPERATION_ID,
+        defaults={
+            'asset': asset,
+            'command': 'RTL',
+            'issued_by': user,
+        },
+    )
+    print('Seeded asset and issued command for persistence checks.')
+
+
+def verify_audit_data(_args):
+    """Verify restored command identity and issuer relationships."""
+    setup_django()
+    from django.contrib.auth import get_user_model  # pylint: disable=import-outside-toplevel
+    from assets.models import AssetCommand  # pylint: disable=import-outside-toplevel
+
+    username = os.environ['DJANGO_SUPERUSER_USERNAME']
+    require(
+        get_user_model().objects.filter(username=username).exists(),
+        'smoke-test user did not survive database recovery',
+    )
+    command = AssetCommand.objects.select_related('asset', 'issued_by').filter(
+        operation_id=SMOKE_OPERATION_ID,
+    ).first()
+    require(command is not None, 'smoke-test command did not survive database recovery')
+    require(command.asset.name == SMOKE_ASSET_NAME, 'command lost its asset relationship')
+    require(command.issued_by is not None, 'command lost its issuing user')
+    require(command.issued_by.username == username, 'command issuer changed during recovery')
+    print('User, asset, and command audit relationships are intact.')
 
 
 def wait_for_login_page(opener, login_url, timeout_seconds):
@@ -124,6 +193,12 @@ def parse_args():
     config_parser.add_argument('database_name')
     config_parser.add_argument('database_password')
     config_parser.set_defaults(handler=verify_config)
+
+    seed_parser = subparsers.add_parser('seed')
+    seed_parser.set_defaults(handler=seed_audit_data)
+
+    audit_parser = subparsers.add_parser('audit')
+    audit_parser.set_defaults(handler=verify_audit_data)
 
     endpoint_parser = subparsers.add_parser('endpoint')
     endpoint_parser.add_argument('--timeout', type=int, default=60)

--- a/test-docker-compose.sh
+++ b/test-docker-compose.sh
@@ -7,6 +7,7 @@ smoke_temp_dir=$(mktemp -d /tmp/fss-compose-smoke.XXXXXX)
 smoke_env_file="${smoke_temp_dir}/smoke.env"
 smoke_project="fss-bug08-smoke-$$"
 smoke_web_container=""
+smoke_backup_file="${smoke_temp_dir}/fss-smoke.dump"
 
 smoke_db_user="fss_smoke_user"
 smoke_db_name="fss_smoke_database"
@@ -54,6 +55,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+start_smoke_web() {
+    smoke_web_container=$("${smoke_compose[@]}" run --detach --no-deps web)
+}
+
+run_web_check() {
+    docker exec \
+        "${smoke_web_container}" \
+        /venv/bin/python \
+        /code/docker/compose-smoke.py \
+        "$@"
+}
+
 required_database_settings=(DB_USER DB_NAME DB_PASS)
 for missing_setting in "${required_database_settings[@]}"
 do
@@ -86,12 +99,30 @@ echo "Compose rejects missing database settings."
 
 "${smoke_compose[@]}" build web
 "${smoke_compose[@]}" up --detach --wait db
-smoke_web_container=$("${smoke_compose[@]}" run --detach --no-deps web)
+start_smoke_web
 
-docker exec \
-    "${smoke_web_container}" \
-    /venv/bin/python \
-    /code/docker/compose-smoke.py \
-    endpoint
+run_web_check endpoint
+run_web_check seed
+run_web_check audit
 
-echo "Fresh-volume Docker Compose smoke test passed."
+"${smoke_compose[@]}" down --remove-orphans
+smoke_web_container=""
+"${smoke_compose[@]}" up --detach --wait db
+start_smoke_web
+run_web_check audit
+
+"${smoke_compose[@]}" exec --no-TTY db sh -c \
+    'PGPASSWORD="$POSTGRES_PASSWORD" exec pg_dump --username="$POSTGRES_USER" --dbname="$POSTGRES_DB" --format=custom' \
+    > "${smoke_backup_file}"
+test -s "${smoke_backup_file}"
+
+"${smoke_compose[@]}" down --volumes --remove-orphans
+smoke_web_container=""
+"${smoke_compose[@]}" up --detach --wait db
+"${smoke_compose[@]}" exec --no-TTY db sh -c \
+    'PGPASSWORD="$POSTGRES_PASSWORD" exec pg_restore --username="$POSTGRES_USER" --dbname="$POSTGRES_DB" --clean --if-exists --no-owner --no-privileges' \
+    < "${smoke_backup_file}"
+start_smoke_web
+run_web_check audit
+
+echo "Docker Compose persistence and restore smoke test passed."


### PR DESCRIPTION
## Description

A project-scoped named volume prevents stack recreation from silently detaching PostgreSQL data. Extend the isolated smoke test to prove both ordinary persistence and logical restore preserve command audit relationships.

## Summary by Sourcery

Ensure PostgreSQL data persists across Compose stack recreation and validate logical backup/restore preserves application audit relationships.

New Features:
- Add a named db-data volume for the PostgreSQL service in Docker Compose to persist database state.
- Extend the Compose smoke test to seed and verify Django asset command audit data across restarts and restore cycles.

Enhancements:
- Refactor the smoke test script and shell harness to support reusable web container startup and audit checks, including backup and restore flows.