### PR TITLE
ops: recover core Compose services

### DIFF
--- a/docker-compose.smoke.yaml
+++ b/docker-compose.smoke.yaml
@@ -1,0 +1,4 @@
+services:
+  web:
+    ports: !override
+      - "127.0.0.1::8080"

--- a/docker-compose.tls.yaml
+++ b/docker-compose.tls.yaml
@@ -2,7 +2,8 @@ services:
   tls-proxy:
     image: nginx:stable-alpine
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     restart: unless-stopped
     ports:
       - "80:80"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   web:
     build: .
+    restart: unless-stopped
     ports:
       - "127.0.0.1:8090:8080"
     depends_on:
@@ -29,6 +30,12 @@ services:
       - TELEMETRY_SEARCH_PROGRESS_RETENTION_DAYS=${TELEMETRY_SEARCH_PROGRESS_RETENTION_DAYS:-}
       - TELEMETRY_ALIGNED_WINDOW_HOURS=${TELEMETRY_ALIGNED_WINDOW_HOURS:-24}
       - COMMAND_AUDIT_RETENTION_DAYS=${COMMAND_AUDIT_RETENTION_DAYS:-}
+    healthcheck:
+      test: ["CMD", "python", "-c", "from urllib.request import urlopen; urlopen('http://127.0.0.1:8080/health/', timeout=5).read()"]
+      interval: 5s
+      timeout: 6s
+      retries: 3
+      start_period: 60s
   telemetry-maintenance:
     build: .
     profiles:
@@ -53,6 +60,7 @@ services:
       - /code/docker/prune-telemetry.sh
   db:
     image: postgis/postgis:18-3.6-alpine
+    restart: unless-stopped
     volumes:
       - db-data:/var/lib/postgresql
     environment:

--- a/docker/compose-smoke.py
+++ b/docker/compose-smoke.py
@@ -29,6 +29,7 @@ def verify_config(args):
     db_service = config['services']['db']
     web_service = config['services']['web']
     maintenance_service = config['services']['telemetry-maintenance']
+    proxy_service = config['services']['tls-proxy']
     expected_db_environment = {
         'POSTGRES_USER': args.database_user,
         'POSTGRES_DB': args.database_name,
@@ -62,6 +63,14 @@ def verify_config(args):
     healthcheck = ' '.join(db_service['healthcheck']['test'])
     require('POSTGRES_USER' in healthcheck, 'database health check does not select POSTGRES_USER')
     require('POSTGRES_DB' in healthcheck, 'database health check does not select POSTGRES_DB')
+    require(db_service.get('restart') == 'unless-stopped', 'database restart policy is not unless-stopped')
+    require(web_service.get('restart') == 'unless-stopped', 'web restart policy is not unless-stopped')
+    web_healthcheck = ' '.join(web_service['healthcheck']['test'])
+    require('/health/' in web_healthcheck, 'web health check does not use application readiness')
+    require(
+        proxy_service.get('depends_on', {}).get('web', {}).get('condition') == 'service_healthy',
+        'TLS proxy does not wait for a healthy web service during initial startup',
+    )
     database_volumes = db_service.get('volumes', [])
     expected_volume = {
         'type': 'volume',
@@ -96,7 +105,7 @@ def seed_audit_data(_args):
     username = os.environ['DJANGO_SUPERUSER_USERNAME']
     user = get_user_model().objects.get(username=username)
     asset, _created = Asset.objects.get_or_create(name=SMOKE_ASSET_NAME)
-    AssetRTT.objects.get_or_create(asset=asset, rtt=25)
+    AssetRTT.objects.create(asset=asset, rtt=25)
     AssetCommand.objects.get_or_create(
         operation_id=SMOKE_OPERATION_ID,
         defaults={
@@ -180,6 +189,32 @@ def verify_endpoint(args):
         status.get('currentUser') == username,
         'authenticated endpoint did not return the smoke-test user',
     )
+    if args.submit_command:
+        command_csrf_token = status.get('csrfToken')
+        require(command_csrf_token is not None, 'status endpoint did not return a CSRF token')
+        asset_id = next(
+            (
+                entry['asset']['pk']
+                for entry in status.get('assets', [])
+                if entry['asset']['name'] == SMOKE_ASSET_NAME
+            ),
+            None,
+        )
+        require(asset_id is not None, 'status endpoint did not return the smoke-test asset')
+        command_data = urlencode({
+            'command': 'RTL',
+            'operation_id': str(uuid.uuid4()),
+        }).encode()
+        command_request = Request(
+            f'{base_url}/assets/{asset_id}/command/set/',
+            data=command_data,
+            headers={'Referer': f'{base_url}/', 'X-CSRFToken': command_csrf_token},
+            method='POST',
+        )
+        with opener.open(command_request, timeout=5) as response:
+            command_response = response.read()
+        require(command_response == b'Queued', 'authenticated command was not queued')
+        print('Authenticated command submission recovered.')
     print(f'Authenticated endpoint returned currentUser={username}.')
 
 
@@ -202,6 +237,7 @@ def parse_args():
 
     endpoint_parser = subparsers.add_parser('endpoint')
     endpoint_parser.add_argument('--timeout', type=int, default=60)
+    endpoint_parser.add_argument('--submit-command', action='store_true')
     endpoint_parser.set_defaults(handler=verify_endpoint)
     return parser.parse_args()
 

--- a/main/tests/test_unauth_sweep.py
+++ b/main/tests/test_unauth_sweep.py
@@ -12,9 +12,11 @@ from django.urls.resolvers import URLPattern, URLResolver
 from assets.models import Asset, AssetCommand
 from fss.satisfies import satisfies
 
-# Endpoints deliberately reachable without authentication: the SPA shell (its
-# auth-gated data is fetched separately via JS) and the login flow itself.
+# Endpoints deliberately reachable without authentication: the deployment
+# health probe, the SPA shell (its auth-gated data is fetched separately via
+# JS), and the login flow itself.
 PUBLIC_URL_NAMES = {
+    'health',
     'main_view',
     'assets_main',
     'config_main',

--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
+from django.db import OperationalError
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -24,6 +25,31 @@ class StatusAPITest(TestCase):
         self.user = get_user_model().objects.create_user(username='testuser', password='password')
         self.asset = Asset.objects.create(name='Test Drone')
         self.server = ServerConfig.objects.create(name='Test Server', address='1.2.3.4', client_port=8080, active=True)
+
+    def test_health_reports_database_ready_without_authentication(self):
+        """The deployment probe succeeds without creating a session."""
+        response = self.client.get(reverse('health'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'ok\n')
+
+    def test_health_reports_database_failure_without_details(self):
+        """Readiness fails closed without exposing database diagnostics."""
+        with patch(
+            'main.views.connection.cursor',
+            side_effect=OperationalError('secret database details'),
+        ):
+            response = self.client.get(reverse('health'))
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.content, b'unavailable\n')
+        self.assertNotContains(response, 'secret database details', status_code=503)
+
+    def test_health_rejects_post(self):
+        """The readiness endpoint remains a read-only interface."""
+        response = self.client.post(reverse('health'))
+
+        self.assertEqual(response.status_code, 405)
 
     def test_all_status_data_unauthenticated(self):
         """Test the all_status_data endpoint rejects unauthenticated requests."""

--- a/main/urls.py
+++ b/main/urls.py
@@ -7,6 +7,7 @@ from django.urls import re_path
 from . import views
 
 urlpatterns = [
+    re_path(r'^health/$', views.health, name='health'),
     re_path(r'^assets.json$', views.asset_list, name='asset_list'),
     re_path(r'^$', views.main_view, name='main_view'),
     re_path(r'^current/all.json/$', views.all_status_data, name='all_status_data'),

--- a/main/views.py
+++ b/main/views.py
@@ -2,16 +2,30 @@
 Main view functions
 """
 from django.contrib.auth import authenticate, login
-from django.http import JsonResponse
+from django.db import DatabaseError, connection
+from django.http import HttpResponse, JsonResponse
 from django.middleware.csrf import get_token
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_GET
 
 from assets.models import Asset
 from assets.views import bulk_asset_status_data, server_now_ms
 from config.asset_configs import active_assets_with_configs
 from config.models import ServerConfig
 from fss.decorators import login_required_api
+
+
+@require_GET
+def health(_request):
+    """Report whether this process can execute an application database query."""
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT 1')
+            cursor.fetchone()
+    except DatabaseError:
+        return HttpResponse('unavailable\n', status=503, content_type='text/plain')
+    return HttpResponse('ok\n', content_type='text/plain')
 
 
 @ensure_csrf_cookie

--- a/test-docker-compose.sh
+++ b/test-docker-compose.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 smoke_repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 smoke_compose_file="${smoke_repo_root}/docker-compose.yaml"
+smoke_compose_override="${smoke_repo_root}/docker-compose.smoke.yaml"
+smoke_tls_compose_file="${smoke_repo_root}/docker-compose.tls.yaml"
 smoke_temp_dir=$(mktemp -d /tmp/fss-compose-smoke.XXXXXX)
 smoke_env_file="${smoke_temp_dir}/smoke.env"
 smoke_project="fss-bug08-smoke-$$"
@@ -29,6 +31,8 @@ CORS_ALLOWED_ORIGINS=
 SESSION_COOKIE_SECURE=false
 CSRF_COOKIE_SECURE=false
 SECURE_HSTS_SECONDS=0
+TLS_CERTIFICATE_PATH=/tmp/fss-smoke-fullchain.pem
+TLS_PRIVATE_KEY_PATH=/tmp/fss-smoke-privkey.pem
 EOF
 
 smoke_compose=(
@@ -36,6 +40,7 @@ smoke_compose=(
     --project-name "${smoke_project}"
     --env-file "${smoke_env_file}"
     --file "${smoke_compose_file}"
+    --file "${smoke_compose_override}"
 )
 
 cleanup() {
@@ -56,7 +61,8 @@ cleanup() {
 trap cleanup EXIT
 
 start_smoke_web() {
-    smoke_web_container=$("${smoke_compose[@]}" run --detach --no-deps web)
+    "${smoke_compose[@]}" up --detach --wait web
+    smoke_web_container=$("${smoke_compose[@]}" ps --quiet web)
 }
 
 run_web_check() {
@@ -65,6 +71,47 @@ run_web_check() {
         /venv/bin/python \
         /code/docker/compose-smoke.py \
         "$@"
+}
+
+wait_for_health() {
+    local container=$1
+    local expected=$2
+    local timeout=$3
+    local deadline=$((SECONDS + timeout))
+    local actual=""
+
+    while ((SECONDS < deadline))
+    do
+        actual=$(docker inspect --format '{{.State.Health.Status}}' "${container}" 2>/dev/null || true)
+        if [[ "${actual}" == "${expected}" ]]
+        then
+            return
+        fi
+        sleep 1
+    done
+    echo "Container ${container} did not become ${expected}; last health was ${actual}." >&2
+    docker inspect "${container}" || true
+    return 1
+}
+
+wait_for_restart() {
+    local container=$1
+    local previous_count=$2
+    local timeout=$3
+    local deadline=$((SECONDS + timeout))
+    local actual=""
+
+    while ((SECONDS < deadline))
+    do
+        actual=$(docker inspect --format '{{.RestartCount}}' "${container}" 2>/dev/null || true)
+        if [[ "${actual}" =~ ^[0-9]+$ ]] && ((actual > previous_count))
+        then
+            return
+        fi
+        sleep 1
+    done
+    echo "Container ${container} did not restart; restart count remained ${actual}." >&2
+    return 1
 }
 
 required_database_settings=(DB_USER DB_NAME DB_PASS)
@@ -90,7 +137,10 @@ do
 done
 echo "Compose rejects missing database settings."
 
-"${smoke_compose[@]}" --profile maintenance config --format json |
+"${smoke_compose[@]}" \
+    --file "${smoke_tls_compose_file}" \
+    --profile maintenance \
+    config --format json |
     python3 "${smoke_repo_root}/docker/compose-smoke.py" \
         config \
         "${smoke_db_user}" \
@@ -98,7 +148,6 @@ echo "Compose rejects missing database settings."
         "${smoke_db_password}"
 
 "${smoke_compose[@]}" build web
-"${smoke_compose[@]}" up --detach --wait db
 start_smoke_web
 
 run_web_check endpoint
@@ -107,7 +156,6 @@ run_web_check audit
 
 "${smoke_compose[@]}" down --remove-orphans
 smoke_web_container=""
-"${smoke_compose[@]}" up --detach --wait db
 start_smoke_web
 run_web_check audit
 
@@ -125,4 +173,30 @@ smoke_web_container=""
 start_smoke_web
 run_web_check audit
 
-echo "Docker Compose persistence and restore smoke test passed."
+# Docker only activates a restart policy after a container has remained up for
+# at least 10 seconds. Cross that guard before simulating an unexpected exit.
+sleep 10
+web_restart_count=$(docker inspect --format '{{.RestartCount}}' "${smoke_web_container}")
+docker exec "${smoke_web_container}" sh -c 'kill -TERM 1' >/dev/null 2>&1 || true
+wait_for_restart "${smoke_web_container}" "${web_restart_count}" 60
+wait_for_health "${smoke_web_container}" healthy 60
+run_web_check endpoint
+
+smoke_db_container=$("${smoke_compose[@]}" ps --quiet db)
+"${smoke_compose[@]}" stop db
+wait_for_health "${smoke_web_container}" unhealthy 45
+"${smoke_compose[@]}" start db
+wait_for_health "${smoke_db_container}" healthy 60
+wait_for_health "${smoke_web_container}" healthy 60
+run_web_check seed
+run_web_check endpoint --submit-command
+
+db_restart_count=$(docker inspect --format '{{.RestartCount}}' "${smoke_db_container}")
+docker exec "${smoke_db_container}" sh -c 'kill -TERM 1' >/dev/null 2>&1 || true
+wait_for_restart "${smoke_db_container}" "${db_restart_count}" 60
+wait_for_health "${smoke_db_container}" healthy 60
+wait_for_health "${smoke_web_container}" healthy 60
+run_web_check seed
+run_web_check endpoint --submit-command
+
+echo "Docker Compose persistence, restore, and restart recovery smoke test passed."


### PR DESCRIPTION
## Description

The proxy can appear available while the application or database is down. Add database-aware readiness, restart policies, and an isolated crash/recovery test that proves authenticated polling and command submission return after service failures.

## Summary by Sourcery

Add database-aware health probing and restart policies to core Compose services and extend smoke tests to prove proxy, web, and database recover correctly after failures.

New Features:
- Introduce a deployment health endpoint that checks database readiness without requiring authentication and exposes no diagnostics.
- Add authenticated command submission checks to the smoke-test endpoint verification.

Enhancements:
- Configure web and database services with restart policies and a web healthcheck used by the TLS proxy for startup gating.
- Update unauthenticated sweep tests and URL configuration to treat the health endpoint as a public read-only interface.
- Adjust Compose smoke tooling and scripts to use multiple compose files, exercise TLS proxy behavior, and validate restart policies and healthchecks.
- Ensure smoke audit seeding always creates a fresh RTT record instead of reusing an existing one.

Tests:
- Extend Docker Compose smoke tests to cover container restart behavior, health transitions on database failures, and recovery of authenticated polling and command submission.
- Add unit tests for the new health endpoint’s success, failure, and method restrictions.