### PR TITLE
fix: report pooled database outages

### DIFF
--- a/main/tests/test_views.py
+++ b/main/tests/test_views.py
@@ -9,6 +9,7 @@ from django.db import OperationalError
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from psycopg_pool import PoolTimeout
 
 from assets.models import Asset, AssetCommand, AssetPosition, AssetRTT, AssetStatus
 from config.asset_configs import duplicate_asset_config_response
@@ -44,6 +45,14 @@ class StatusAPITest(TestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.content, b'unavailable\n')
         self.assertNotContains(response, 'secret database details', status_code=503)
+
+    def test_health_reports_connection_pool_timeout(self):
+        """An exhausted external-database pool is an unavailable service."""
+        with patch('main.views.connection.cursor', side_effect=PoolTimeout()):
+            response = self.client.get(reverse('health'))
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.content, b'unavailable\n')
 
     def test_health_rejects_post(self):
         """The readiness endpoint remains a read-only interface."""

--- a/main/views.py
+++ b/main/views.py
@@ -8,6 +8,7 @@ from django.middleware.csrf import get_token
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET
+from psycopg_pool import PoolTimeout
 
 from assets.models import Asset
 from assets.views import bulk_asset_status_data, server_now_ms
@@ -23,7 +24,7 @@ def health(_request):
         with connection.cursor() as cursor:
             cursor.execute('SELECT 1')
             cursor.fetchone()
-    except DatabaseError:
+    except (DatabaseError, PoolTimeout):
         return HttpResponse('unavailable\n', status=503, content_type='text/plain')
     return HttpResponse('ok\n', content_type='text/plain')
 


### PR DESCRIPTION
## Description

Direct installs can surface Psycopg PoolTimeout without Django wrapping it as DatabaseError. Treat that condition as unavailable so the shared health endpoint consistently returns 503 instead of leaking a server error.

## Summary by Sourcery

Treat exhausted external database connection pools as a database outage in the health endpoint.

Bug Fixes:
- Ensure the health endpoint returns 503 and an 'unavailable' response when psycopg connection pools hit PoolTimeout instead of surfacing a server error.

Tests:
- Add a health endpoint test verifying that a PoolTimeout from the database connection pool is reported as an unavailable service.