### PR TITLE
feat: record GPS validity with positions

### DIFF
--- a/assets/migrations/0016_assetposition_gps_fix_valid.py
+++ b/assets/migrations/0016_assetposition_gps_fix_valid.py
@@ -1,0 +1,63 @@
+import django.contrib.gis.db.models.fields
+from django.db import migrations, models
+
+
+def allow_missing_position(_apps, schema_editor):
+    """Drop the PostGIS NOT NULL constraint; SpatiaLite permits NULL already."""
+    if schema_editor.connection.vendor != 'postgresql':
+        return
+    schema_editor.execute(
+        'ALTER TABLE assets_assetposition '
+        'ALTER COLUMN position DROP NOT NULL'
+    )
+
+
+def require_position(_apps, schema_editor):
+    """Restore the old constraint when rolling back a database with no NULLs."""
+    if schema_editor.connection.vendor != 'postgresql':
+        return
+    schema_editor.execute(
+        'ALTER TABLE assets_assetposition '
+        'ALTER COLUMN position SET NOT NULL'
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0015_command_operation_id'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    allow_missing_position,
+                    require_position,
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name='assetposition',
+                    name='position',
+                    field=django.contrib.gis.db.models.fields.PointField(
+                        geography=True,
+                        null=True,
+                        srid=4326,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddField(
+            model_name='assetposition',
+            name='gps_fix_valid',
+            field=models.BooleanField(db_default=True, default=True),
+        ),
+        migrations.AddIndex(
+            model_name='assetposition',
+            index=models.Index(
+                fields=['asset', 'gps_fix_valid', '-timestamp'],
+                name='asset_pos_fix_time_idx',
+            ),
+        ),
+    ]

--- a/assets/models.py
+++ b/assets/models.py
@@ -90,8 +90,13 @@ class AssetPosition(models.Model):
     """
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE)
     timestamp = models.DateTimeField(default=timezone.now)
-    position = models.PointField(geography=True)
+    # A no-fix report can still carry the autopilot's dead-reckoned estimate.
+    # NULL is reserved for reports where even that estimate is unavailable.
+    position = models.PointField(geography=True, null=True)
     altitude = models.IntegerField(default=0)
+    # Keep a database default because the FSS writer uses raw SQL and older
+    # deployments omit this column while the services are upgraded in stages.
+    gps_fix_valid = models.BooleanField(default=True, db_default=True)
 
     def __str__(self):
         return f"{self.asset} @ {self.position} alt={self.altitude} ({self.timestamp})"
@@ -99,6 +104,10 @@ class AssetPosition(models.Model):
     class Meta:
         indexes = [
             models.Index(fields=['asset', '-timestamp', ]),
+            models.Index(
+                fields=['asset', 'gps_fix_valid', '-timestamp'],
+                name='asset_pos_fix_time_idx',
+            ),
         ]
 
 

--- a/assets/tests/test_models.py
+++ b/assets/tests/test_models.py
@@ -5,12 +5,12 @@
 import uuid
 
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
 from django.db.models.deletion import ProtectedError
 from django.test import TestCase
 from django.utils import timezone
 
-from assets.models import Asset, AssetCommand, AssetCommandAck
+from assets.models import Asset, AssetCommand, AssetCommandAck, AssetPosition
 
 
 class AssetLifecycleTest(TestCase):
@@ -75,6 +75,37 @@ class AssetLifecycleTest(TestCase):
             AssetCommand.objects.create(
                 asset=asset, command='MAN', operation_id=operation_id,
             )
+
+
+class AssetPositionGPSFixTest(TestCase):
+    """Position rows distinguish GPS fixes from untrusted estimates."""
+
+    def setUp(self):
+        self.asset = Asset.objects.create(name='Position asset')
+
+    def test_database_default_keeps_legacy_writer_positions_valid(self):
+        """A raw insert that omits gps_fix_valid remains deploy-compatible."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'INSERT INTO assets_assetposition '
+                '(asset_id, timestamp, position, altitude) '
+                'VALUES (%s, %s, NULL, %s)',
+                [self.asset.pk, timezone.now(), 100],
+            )
+
+        position = AssetPosition.objects.get(asset=self.asset)
+        self.assertTrue(position.gps_fix_valid)
+
+    def test_no_fix_report_can_omit_position_estimate(self):
+        position = AssetPosition.objects.create(
+            asset=self.asset,
+            position=None,
+            altitude=100,
+            gps_fix_valid=False,
+        )
+
+        self.assertIsNone(position.position)
+        self.assertFalse(position.gps_fix_valid)
 
 
 class AssetCommandAckTest(TestCase):


### PR DESCRIPTION
## Description

Position reports need to distinguish GPS-backed coordinates from dead-reckoned estimates while remaining compatible with older raw-SQL FSS writers. A nullable geometry also preserves no-fix state when no finite estimate is available.

## Summary by Sourcery

Allow asset positions to record GPS fix validity and support missing position estimates while maintaining compatibility with legacy raw-SQL writers.

New Features:
- Add a gps_fix_valid flag to asset position records to distinguish GPS-backed fixes from untrusted estimates.

Enhancements:
- Permit nullable position geometry for asset positions to represent reports without any available position estimate.
- Add a composite index over asset, GPS fix validity, and timestamp to support querying recent valid and invalid positions efficiently.

Tests:
- Introduce tests verifying database defaults for gps_fix_valid and behavior when position is omitted in no-fix reports.