### PR TITLE
feat: expose GPS fix and position estimates

### DIFF
--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -9,8 +9,9 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
 from django.contrib.sessions.models import Session
-from django.db import IntegrityError
+from django.db import IntegrityError, connection
 from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -692,6 +693,8 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['position']['lat'], -43.0)
         self.assertEqual(data['position']['lng'], 172.0)
         self.assertEqual(data['position']['alt'], 120)
+        self.assertTrue(data['gps']['fix_valid'])
+        self.assertNotIn('position_estimate', data)
 
         self.assertEqual(data['status']['battery_percent'], 85)
         self.assertEqual(data['status']['battery_used'], 500)
@@ -700,6 +703,85 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['search']['id'], 7)
         self.assertEqual(data['search']['progress'], 3)
         self.assertEqual(data['search']['total'], 10)
+
+    def test_all_status_data_no_fix_includes_last_fix_and_estimate(self):
+        """A no-fix report keeps trusted and dead-reckoned positions separate."""
+        self.client.force_login(self.user)
+        now = timezone.now()
+        last_fix = now - timedelta(seconds=12)
+        AssetPosition.objects.create(
+            asset=self.asset,
+            timestamp=last_fix,
+            position=Point(172.0, -43.0),
+            altitude=120,
+        )
+        AssetPosition.objects.create(
+            asset=self.asset,
+            timestamp=now,
+            position=Point(172.001, -43.001),
+            altitude=121,
+            gps_fix_valid=False,
+        )
+
+        data = self._get_asset_status()
+
+        self.assertFalse(data['gps']['fix_valid'])
+        self.assertLess(
+            abs(parse_datetime(data['gps']['timestamp']) - now),
+            timedelta(milliseconds=1),
+        )
+        self.assertLess(
+            abs(parse_datetime(data['position']['timestamp']) - last_fix),
+            timedelta(milliseconds=1),
+        )
+        self.assertEqual(data['position']['lat'], -43.0)
+        self.assertEqual(data['position_estimate']['lat'], -43.001)
+        self.assertEqual(data['position_estimate']['lng'], 172.001)
+
+    def test_all_status_data_no_fix_without_estimate_keeps_last_fix(self):
+        """No-fix state remains visible when the aircraft has no estimate."""
+        self.client.force_login(self.user)
+        AssetPosition.objects.create(
+            asset=self.asset,
+            position=Point(172.0, -43.0),
+            altitude=120,
+        )
+        AssetPosition.objects.create(
+            asset=self.asset,
+            position=None,
+            altitude=0,
+            gps_fix_valid=False,
+        )
+
+        data = self._get_asset_status()
+
+        self.assertFalse(data['gps']['fix_valid'])
+        self.assertIn('position', data)
+        self.assertNotIn('position_estimate', data)
+
+    def test_all_status_data_restored_fix_hides_old_estimate(self):
+        """A newer valid fix becomes current and retires the warning estimate."""
+        self.client.force_login(self.user)
+        now = timezone.now()
+        AssetPosition.objects.create(
+            asset=self.asset,
+            timestamp=now - timedelta(seconds=2),
+            position=Point(172.001, -43.001),
+            altitude=121,
+            gps_fix_valid=False,
+        )
+        AssetPosition.objects.create(
+            asset=self.asset,
+            timestamp=now,
+            position=Point(172.002, -43.002),
+            altitude=122,
+        )
+
+        data = self._get_asset_status()
+
+        self.assertTrue(data['gps']['fix_valid'])
+        self.assertEqual(data['position']['lat'], -43.002)
+        self.assertNotIn('position_estimate', data)
 
     def test_all_status_data_ack_pending(self):
         """A dispatched-but-unacked command reports ack_state 'pending'."""
@@ -770,8 +852,32 @@ class AssetAPITest(TestCase):
         self.assertEqual(data['asset']['name'], 'Empty Drone')
         self.assertFalse(data['connected'])
         self.assertNotIn('position', data)
+        self.assertNotIn('position_estimate', data)
+        self.assertNotIn('gps', data)
         self.assertNotIn('status', data)
         self.assertNotIn('rtt', data)
+
+    def test_bulk_asset_status_gps_queries_do_not_scale_with_assets(self):
+        """Paired position lookup remains bulk rather than one query per asset."""
+        AssetPosition.objects.create(
+            asset=self.asset,
+            position=Point(172.0, -43.0),
+            altitude=120,
+        )
+        other = Asset.objects.create(name='Query Count Drone')
+        AssetPosition.objects.create(
+            asset=other,
+            position=Point(173.0, -44.0),
+            altitude=130,
+            gps_fix_valid=False,
+        )
+
+        with CaptureQueriesContext(connection) as single_queries:
+            bulk_asset_status_data(Asset.objects.filter(pk=self.asset.pk))
+        with CaptureQueriesContext(connection) as fleet_queries:
+            bulk_asset_status_data(Asset.objects.all())
+
+        self.assertEqual(len(fleet_queries), len(single_queries))
 
     def test_rtt_sample_limit(self):
         """Test that RTT calculation only uses the latest RTT_SAMPLE_LIMIT samples."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -74,7 +74,7 @@ def assets_main(request):
 
 
 def _format_position(pos):
-    if not pos:
+    if not pos or pos.position is None:
         return None
     return {
         'timestamp': pos.timestamp,
@@ -186,7 +186,7 @@ def _format_command(cmd):
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
-def format_asset_status(asset, position=None, status=None, search=None, rtts=None, command=None, now=None):
+def format_asset_status(asset, position=None, position_report=None, status=None, search=None, rtts=None, command=None, now=None):
     """
     Centralized formatting logic for asset status data.
     """
@@ -204,6 +204,14 @@ def format_asset_status(asset, position=None, status=None, search=None, rtts=Non
     pos_data = _format_position(position)
     if pos_data:
         data['position'] = pos_data
+
+    if position_report:
+        data['gps'] = {
+            'timestamp': position_report.timestamp,
+            'fix_valid': position_report.gps_fix_valid,
+        }
+        if not position_report.gps_fix_valid and position_report.position is not None:
+            data['position_estimate'] = _format_position(position_report)
 
     stat_data = _format_status(status)
     if stat_data:
@@ -229,10 +237,10 @@ def bulk_asset_status_data(assets):
     Get current status data for a list of assets efficiently.
     """
 
-    def latest_subquery(model):
+    def latest_subquery(model, **filters):
         return (
             model.objects
-            .filter(asset=OuterRef('pk'))
+            .filter(asset=OuterRef('pk'), **filters)
             .order_by('-timestamp')
             .values('pk')[:1]
         )
@@ -241,6 +249,11 @@ def bulk_asset_status_data(assets):
     annotated_assets = list(
         assets.annotate(
             pos_id=Subquery(latest_subquery(AssetPosition)),
+            valid_pos_id=Subquery(latest_subquery(
+                AssetPosition,
+                gps_fix_valid=True,
+                position__isnull=False,
+            )),
             stat_id=Subquery(latest_subquery(AssetStatus)),
             srch_id=Subquery(latest_subquery(AssetSearchProgress)),
             cmd_id=Subquery(latest_subquery(AssetCommand)),
@@ -250,9 +263,14 @@ def bulk_asset_status_data(assets):
     # Fetch latest objects for all assets in 4 bulk queries
     latest = {
         'positions': {
-            p.asset_id: p
+            p.pk: p
             for p in AssetPosition.objects.filter(
-                pk__in=[a.pos_id for a in annotated_assets if a.pos_id]
+                pk__in={
+                    position_id
+                    for a in annotated_assets
+                    for position_id in (a.pos_id, a.valid_pos_id)
+                    if position_id
+                }
             )
         },
         'statuses': {
@@ -302,7 +320,8 @@ def bulk_asset_status_data(assets):
         results.append(
             format_asset_status(
                 asset,
-                position=latest['positions'].get(asset.pk),
+                position=latest['positions'].get(asset.valid_pos_id),
+                position_report=latest['positions'].get(asset.pos_id),
                 status=latest['statuses'].get(asset.pk),
                 search=latest['searches'].get(asset.pk),
                 rtts=rtts_by_asset.get(asset.pk, []),


### PR DESCRIPTION
## Description

Operators need both the last GPS-backed location and any current dead-reckoned estimate. The bulk API now returns that distinction without adding per-asset queries and keeps no-data and fix-restoration states explicit.

## Summary by Sourcery

Expose GPS fix metadata and distinguish between last valid GPS position and current position estimate in asset status responses while keeping bulk lookup efficient.

New Features:
- Include GPS fix status and timestamp in asset status payloads.
- Provide separate fields for last trusted GPS position and current dead-reckoned position estimate when the fix is invalid.

Enhancements:
- Extend bulk asset status query to fetch both latest position report and latest valid GPS-backed position without per-asset queries.
- Ensure no-data asset responses omit GPS and position-related fields consistently.

Tests:
- Add coverage for GPS fix visibility, position vs estimate behavior across fix/no-fix/restored states, no-data responses, and query-count scaling for bulk asset status.