### PR TITLE
feat: warn on GPS loss with paired positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Operator Visibility
+
+- **GPS-fix and dead-reckoning status** — asset polling distinguishes the latest GPS-backed position from a no-fix dead-reckoned estimate, reports their server-timestamp interval, and keeps the warning visible while each coordinate record ages independently. The migration must land before FSS starts writing the new validity field.
+
 ### Security
 
 - **Idempotent command operations** — authenticated command and destructive-confirmation POSTs now require one UUID operation ID across every redundant peer. Identical retries return the committed command without another insert or confirmation, conflicting reuse returns `409` and is logged, and the frontend retries only unresolved peers while disabling concurrent controls for that asset.

--- a/frontend/fss-main-page.test.tsx
+++ b/frontend/fss-main-page.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { degreesToDM } from '@canterbury-air-patrol/deg-converter'
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -99,6 +100,77 @@ describe('asset command rendering', () => {
     render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
 
     expect(screen.getByText('Goto Position 0 0.000 N, 0 0.000 E')).toBeTruthy()
+  })
+})
+
+describe('GPS fix rendering', () => {
+  // satisfies: TC-FS-002
+  it('shows the last GPS position, dead-reckoned estimate, and their interval', () => {
+    const servers = { [SERVER_KEY]: makeServer() }
+    const lastFix = new Date(SERVER_NOW - 12_000).toISOString()
+    const estimate = new Date(SERVER_NOW).toISOString()
+    const status: AssetStatus = {
+      ...cannedAssetStatus(true),
+      gps: { timestamp: estimate, fix_valid: false },
+      position: { timestamp: lastFix, lat: -43, lng: 172, alt: 120 },
+      position_estimate: { timestamp: estimate, lat: -43.001, lng: 172.001, alt: 121 }
+    }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [status], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    const warning = screen.getByText('No GPS Fix').closest('[role="alert"]')!
+    expect(warning.textContent).toContain('Dead-reckoned estimate is 12 s after the last GPS fix.')
+    expect(screen.getByText('Last GPS position')).toBeTruthy()
+    expect(screen.getByText('Dead-reckoned estimate')).toBeTruthy()
+    expect(screen.getByText(degreesToDM(-43, 'lat'))).toBeTruthy()
+    expect(screen.getByText(degreesToDM(-43.001, 'lat'))).toBeTruthy()
+  })
+
+  it('explains when no dead-reckoned coordinates are available', () => {
+    const servers = { [SERVER_KEY]: makeServer() }
+    const timestamp = new Date(SERVER_NOW).toISOString()
+    const status: AssetStatus = {
+      ...cannedAssetStatus(true),
+      gps: { timestamp, fix_valid: false },
+      position: { timestamp, lat: -43, lng: 172, alt: 120 }
+    }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [status], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('No dead-reckoned position is available; showing the last GPS position.')
+  })
+
+  it('explains when no GPS-backed position has been recorded', () => {
+    const servers = { [SERVER_KEY]: makeServer() }
+    const timestamp = new Date(SERVER_NOW).toISOString()
+    const status: AssetStatus = {
+      ...cannedAssetStatus(true),
+      gps: { timestamp, fix_valid: false },
+      position_estimate: { timestamp, lat: -43.001, lng: 172.001, alt: 121 }
+    }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [status], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('No GPS-backed position has been recorded; showing the dead-reckoned estimate.')
+  })
+
+  it('does not warn when the latest report has a valid GPS fix', () => {
+    const servers = { [SERVER_KEY]: makeServer() }
+    const timestamp = new Date(SERVER_NOW).toISOString()
+    const status: AssetStatus = {
+      ...cannedAssetStatus(true),
+      gps: { timestamp, fix_valid: true },
+      position: { timestamp, lat: -43, lng: 172, alt: 120 }
+    }
+    const asset = mergeServerAssets({}, SERVER_KEY, 'alpha', [status], SERVER_NOW).Drone
+
+    render(<FSSAsset asset={asset} knownServers={servers} setSelected={vi.fn()} />)
+
+    expect(screen.queryByText('No GPS Fix')).toBeNull()
+    expect(screen.queryByText('Dead-reckoned estimate')).toBeNull()
   })
 })
 

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -22,6 +22,7 @@ import {
   rttTimeWarn,
   rttTimeOld,
   dataAgeClass,
+  positionEstimateDeltaSeconds,
   commandAckDisplay,
   assetServerMisalignment
 } from './rendering'
@@ -241,8 +242,36 @@ const FSSAssetCommandMisalignment: React.FC<{ asset: AssetState }> = ({ asset })
   )
 }
 
+const FSSPositionTable: React.FC<{
+  position: AssetPositionData
+  label?: string
+  agePrefix: string
+  serverNow?: number
+}> = ({ position, label, agePrefix, serverNow }) => (
+  <div className="asset-position-block">
+    {label && <div className="asset-position-label">{label}</div>}
+    <table className={'asset-position ' + dataAgeClass(position.timestamp, assetPositionTimeOld, assetPositionTimeWarn, agePrefix, serverNow)}>
+      <thead>
+        <tr>
+          <td>Latitude</td>
+          <td>Longitude</td>
+          <td>Altitude (ft)</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{degreesToDM(position.lat, 'lat')}</td>
+          <td>{degreesToDM(position.lng, 'lon')}</td>
+          <td>{position.alt ?? 'N/A'}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+)
+
 const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: string }> = ({ server, serverLabel }) => {
   const { data } = server
+  const noGpsFix = data?.gps?.fix_valid === false
   let rttTable
   if (data?.rtt) {
     rttTable = (
@@ -268,23 +297,29 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
   }
   let posTable
   if (data?.position) {
-    posTable = (
-      <table className={'asset-positon ' + dataAgeClass(data.position.timestamp, assetPositionTimeOld, assetPositionTimeWarn, 'asset-position', server.serverNow)}>
-        <thead>
-          <tr>
-            <td>Latitude</td>
-            <td>Longitude</td>
-            <td>Altitude (ft)</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{degreesToDM(data.position.lat, 'lat')}</td>
-            <td>{degreesToDM(data.position.lng, 'lon')}</td>
-            <td>{data.position.alt ?? 'N/A'}</td>
-          </tr>
-        </tbody>
-      </table>
+    posTable = <FSSPositionTable position={data.position} label={noGpsFix ? 'Last GPS position' : undefined} agePrefix="asset-position" serverNow={server.serverNow} />
+  }
+  let positionEstimateTable
+  if (noGpsFix && data.position_estimate) {
+    positionEstimateTable = <FSSPositionTable position={data.position_estimate} label="Dead-reckoned estimate" agePrefix="asset-position-estimate" serverNow={server.serverNow} />
+  }
+  let gpsWarning
+  if (noGpsFix) {
+    let detail
+    if (data.position && data.position_estimate) {
+      const delta = positionEstimateDeltaSeconds(data.position.timestamp, data.position_estimate.timestamp)
+      detail = `Dead-reckoned estimate is ${delta} s after the last GPS fix.`
+    } else if (data.position) {
+      detail = 'No dead-reckoned position is available; showing the last GPS position.'
+    } else if (data.position_estimate) {
+      detail = 'No GPS-backed position has been recorded; showing the dead-reckoned estimate.'
+    } else {
+      detail = 'No GPS-backed or dead-reckoned position is available.'
+    }
+    gpsWarning = (
+      <div className="alert alert-warning asset-gps-warning" role="alert">
+        <strong>No GPS Fix</strong> — {detail}
+      </div>
     )
   }
   let batteryTable
@@ -360,8 +395,10 @@ const FSSAssetServerStatus: React.FC<{ server: AssetServerState; serverLabel: st
         {commandTxt}
         {commandAck}
       </div>
+      {gpsWarning}
       {rttTable}
       {posTable}
+      {positionEstimateTable}
       {batteryTable}
       {searchTable}
     </div>

--- a/frontend/fssweb.css
+++ b/frontend/fssweb.css
@@ -68,6 +68,7 @@ div.server-label-connected {
 }
 
 .asset-position-warn,
+.asset-position-estimate-warn,
 .asset-battery-time-warn,
 .asset-search-time-warn,
 .asset-rtt-time-warn {
@@ -77,12 +78,22 @@ div.server-label-connected {
 }
 
 .asset-position-old,
+.asset-position-estimate-old,
 .asset-battery-time-old,
 .asset-search-time-old,
 .asset-rtt-time-old {
   color: red;
   font-style: italic;
   opacity: 25%;
+}
+
+.asset-gps-warning {
+  margin: 0.5rem 0;
+}
+
+.asset-position-label {
+  font-weight: bold;
+  margin-top: 0.5rem;
 }
 
 .asset-battery-warn {

--- a/frontend/rendering.test.ts
+++ b/frontend/rendering.test.ts
@@ -13,6 +13,7 @@ import {
   commandAckOutcome,
   commandAckTimeout,
   dataAgeClass,
+  positionEstimateDeltaSeconds,
   supersededRtlInEffect
 } from './rendering'
 
@@ -88,6 +89,16 @@ describe('dataAgeClass', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('positionEstimateDeltaSeconds', () => {
+  it('reports the rounded interval after the last GPS-backed position', () => {
+    expect(positionEstimateDeltaSeconds(isoAt(12_400), isoAt(0))).toBe(12)
+  })
+
+  it('does not report a negative interval for reordered timestamps', () => {
+    expect(positionEstimateDeltaSeconds(isoAt(0), isoAt(1000))).toBe(0)
   })
 })
 

--- a/frontend/rendering.ts
+++ b/frontend/rendering.ts
@@ -44,6 +44,12 @@ export const dataAgeClass = (timestamp: string, old: number, warn: number, prefi
   return ''
 }
 
+// How far the dead-reckoned estimate has advanced in time beyond the last
+// GPS-backed position. Database receipt timestamps share one server clock, so
+// this comparison is immune to browser and aircraft clock skew.
+export const positionEstimateDeltaSeconds = (lastFixTimestamp: string, estimateTimestamp: string): number =>
+  Math.max(0, Math.round((new Date(estimateTimestamp).getTime() - new Date(lastFixTimestamp).getTime()) / 1000))
+
 // Label for the reason a command was superseded. The failsafe latches always
 // engage an RTL, so name those as such for the operator; a newer command
 // simply overrides the older one and is not an RTL.

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -5,6 +5,11 @@ export interface AssetPositionData {
   alt?: number
 }
 
+export interface AssetGPSData {
+  timestamp: string
+  fix_valid: boolean
+}
+
 export interface AssetStatusData {
   timestamp: string
   battery_percent: number
@@ -61,6 +66,11 @@ export interface AssetStatus {
   // command submission treats a missing value as disconnected.
   connected?: boolean
   position?: AssetPositionData
+  // The latest position report says whether coordinates are backed by GPS.
+  // During a no-fix period, position remains the last trusted GPS location and
+  // position_estimate carries the autopilot's current dead-reckoned estimate.
+  gps?: AssetGPSData
+  position_estimate?: AssetPositionData
   status?: AssetStatusData
   search?: AssetSearchData
   rtt?: AssetRTTData


### PR DESCRIPTION
## Description

A no-fix condition must be explicit without hiding useful navigation context. The operator view now labels the last GPS-backed location beside the dead-reckoned estimate, reports their time separation, and documents the upstream deployment contract.

## Summary by Sourcery

Warn operators when GPS fix is lost by distinguishing GPS-backed positions from dead-reckoned estimates and surfacing their time separation in the asset view.

New Features:
- Display both the last GPS-backed position and the current dead-reckoned estimate for an asset when the GPS fix is invalid.
- Show a explicit warning banner whenever an asset reports no GPS fix, including contextual messaging based on available position data.

Enhancements:
- Introduce a reusable position table component that consistently renders asset coordinates with age-based styling for both GPS and dead-reckoned data.
- Add a helper to compute the server-timestamp interval between the last GPS-backed position and the dead-reckoned estimate and prevent negative intervals.
- Extend CSS styling to cover dead-reckoned position age states and to visually emphasize GPS warnings and position labels.

Documentation:
- Document the new GPS-fix and dead-reckoning visibility behaviour in the changelog, including the deployment contract around the GPS validity field.

Tests:
- Add frontend tests to verify GPS warning behaviour, position labelling, and rendering of paired GPS and dead-reckoned coordinates under various data conditions.
- Add unit tests for the positionEstimateDeltaSeconds helper to cover normal and reordered timestamp cases.