### PR TITLE
fix: reconcile discovered server topology

### DIFF
--- a/frontend/asset.test.ts
+++ b/frontend/asset.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AssetState, CommandDispatchError, createAsset, mergeServerAssets, sendAssetCommand } from './asset'
+import { AssetState, CommandDispatchError, createAsset, mergeServerAssets, pruneAssetServers, sendAssetCommand } from './asset'
 import { ServerState, createServer } from './server'
 import { AssetStatus } from './server'
 
@@ -460,5 +460,27 @@ describe('mergeServerAssets', () => {
 
     expect(Object.keys(result)).toEqual(['Drone'])
     expect(result.Drone.servers['alpha-origin'].assetPk).toBe(5)
+  })
+})
+
+describe('pruneAssetServers', () => {
+  it('removes obsolete origin entries and falls back to a retained selection', () => {
+    const first = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Drone', 5)])
+    const both = mergeServerAssets(first, 'beta-origin', 'beta', [statusFor('Drone', 9)])
+
+    const result = pruneAssetServers(both, new Set(['beta-origin']))
+
+    expect(Object.keys(result.Drone.servers)).toEqual(['beta-origin'])
+    expect(result.Drone.selectedServerKey).toBe('beta-origin')
+  })
+
+  it('drops orphaned assets without disturbing assets on retained origins', () => {
+    const obsolete = mergeServerAssets({}, 'alpha-origin', 'alpha', [statusFor('Old Drone', 5)])
+    const assets = mergeServerAssets(obsolete, 'beta-origin', 'beta', [statusFor('Current Drone', 9)])
+
+    const result = pruneAssetServers(assets, new Set(['beta-origin']))
+
+    expect(result['Old Drone']).toBeUndefined()
+    expect(result['Current Drone'].servers['beta-origin'].assetPk).toBe(9)
   })
 })

--- a/frontend/asset.tsx
+++ b/frontend/asset.tsx
@@ -282,6 +282,24 @@ const pruneStaleServerEntries = (currentAssets: Record<string, AssetState>, serv
   return nextAssets
 }
 
+// Reconcile asset-server entries after topology reconciliation removes an
+// origin. This is separate from per-poll asset reconciliation because topology
+// removal may be triggered by a different server's advertised peer snapshot.
+export const pruneAssetServers = (currentAssets: Record<string, AssetState>, retainedServerKeys: Set<string>): Record<string, AssetState> => {
+  const nextAssets: Record<string, AssetState> = {}
+  for (const [assetName, assetState] of Object.entries(currentAssets)) {
+    const remainingServers = Object.fromEntries(Object.entries(assetState.servers).filter(([serverKey]) => retainedServerKeys.has(serverKey)))
+    const remainingServerKeys = Object.keys(remainingServers)
+    if (remainingServerKeys.length === 0) continue
+    nextAssets[assetName] = {
+      ...assetState,
+      servers: remainingServers,
+      selectedServerKey: assetState.selectedServerKey && retainedServerKeys.has(assetState.selectedServerKey) ? assetState.selectedServerKey : remainingServerKeys[0]
+    }
+  }
+  return nextAssets
+}
+
 export const mergeServerAssets = (
   currentAssets: Record<string, AssetState>,
   serverKey: string,

--- a/frontend/server.test.ts
+++ b/frontend/server.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { ServerState, StatusData, canonicalServerOrigin, createServer, mergeServerPollResult } from './server'
+import {
+  ServerState,
+  StatusData,
+  canonicalServerOrigin,
+  createServer,
+  mergeServerPollResult,
+  reconcileServerTopology,
+  serverConnectFailed,
+  serverTopologyMismatch,
+  serverUnauthenticated
+} from './server'
 
 const statusData = (overrides: Partial<StatusData> = {}): StatusData => ({
   csrfToken: 'tok',
@@ -74,5 +84,107 @@ describe('mergeServerPollResult', () => {
     expect(Object.keys(result).sort()).toEqual([firstOrigin, secondOrigin])
     expect(result[firstOrigin].url).toBe(firstOrigin)
     expect(result[secondOrigin].url).toBe(secondOrigin)
+  })
+
+  it('stores canonical advertised origins from the latest successful snapshot', () => {
+    const alphaOrigin = canonicalServerOrigin('https://alpha.example')
+    const current = { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) }
+    const result = mergeServerPollResult(
+      current,
+      alphaOrigin,
+      statusData({ servers: [{ name: 'beta', address: '10.0.0.2', client_port: 9090, url: 'https://BETA.example:443/' }] })
+    )
+
+    expect(result[alphaOrigin].advertisedOrigins).toEqual(['https://beta.example'])
+  })
+})
+
+describe('reconcileServerTopology', () => {
+  const alphaOrigin = canonicalServerOrigin('https://alpha.example')
+  const betaOrigin = canonicalServerOrigin('https://beta.example')
+  const gammaOrigin = canonicalServerOrigin('https://gamma.example')
+
+  const details = (name: string, url: string): { name: string; address: string; client_port: number; url: string } => ({
+    name,
+    address: new URL(url).hostname,
+    client_port: 9090,
+    url
+  })
+
+  it('removes a peer omitted from the direct server latest successful snapshot', () => {
+    let servers = mergeServerPollResult(
+      { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) },
+      alphaOrigin,
+      statusData({ servers: [details('beta', betaOrigin)] })
+    )
+    servers = reconcileServerTopology(servers, alphaOrigin)
+
+    servers = mergeServerPollResult(servers, alphaOrigin, statusData())
+    servers = reconcileServerTopology(servers, alphaOrigin)
+
+    expect(Object.keys(servers)).toEqual([alphaOrigin])
+  })
+
+  it('retains the direct root even when no snapshot advertises it', () => {
+    const servers = mergeServerPollResult(
+      { [alphaOrigin]: createServer('direct', '127.0.0.1', 0, alphaOrigin) },
+      alphaOrigin,
+      statusData({ servers: [details('beta', betaOrigin)] })
+    )
+
+    expect(Object.keys(reconcileServerTopology(servers, alphaOrigin)).sort()).toEqual([alphaOrigin, betaOrigin])
+  })
+
+  it('retains topology across failed and unauthenticated polls', () => {
+    let servers = mergeServerPollResult(
+      { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) },
+      alphaOrigin,
+      statusData({ servers: [details('beta', betaOrigin)] })
+    )
+
+    servers = { ...servers, [alphaOrigin]: serverConnectFailed(servers[alphaOrigin]) }
+    expect(Object.keys(reconcileServerTopology(servers, alphaOrigin)).sort()).toEqual([alphaOrigin, betaOrigin])
+
+    servers = { ...servers, [alphaOrigin]: serverUnauthenticated(servers[alphaOrigin]) }
+    expect(Object.keys(reconcileServerTopology(servers, alphaOrigin)).sort()).toEqual([alphaOrigin, betaOrigin])
+  })
+
+  it('keeps a peer advertised by another retained server and reports disagreement', () => {
+    let servers = mergeServerPollResult(
+      { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) },
+      alphaOrigin,
+      statusData({ servers: [details('beta', betaOrigin), details('gamma', gammaOrigin)] })
+    )
+    servers = mergeServerPollResult(servers, gammaOrigin, statusData({ servers: [details('alpha', alphaOrigin), details('beta', betaOrigin)] }))
+    servers = mergeServerPollResult(servers, alphaOrigin, statusData({ servers: [details('gamma', gammaOrigin)] }))
+    servers = reconcileServerTopology(servers, alphaOrigin)
+
+    expect(Object.keys(servers).sort()).toEqual([alphaOrigin, betaOrigin, gammaOrigin])
+    expect(serverTopologyMismatch(Object.values(servers)).map((snapshot) => snapshot.serverName)).toEqual(['alpha', 'gamma'])
+  })
+
+  it('replaces an obsolete peer URL without disturbing the root', () => {
+    let servers = mergeServerPollResult(
+      { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) },
+      alphaOrigin,
+      statusData({ servers: [details('beta', betaOrigin)] })
+    )
+    servers = reconcileServerTopology(servers, alphaOrigin)
+
+    servers = mergeServerPollResult(servers, alphaOrigin, statusData({ servers: [details('gamma', gammaOrigin)] }))
+    servers = reconcileServerTopology(servers, alphaOrigin)
+
+    expect(Object.keys(servers).sort()).toEqual([alphaOrigin, gammaOrigin])
+  })
+
+  it('treats symmetric peer lists as the same complete topology', () => {
+    let servers = mergeServerPollResult(
+      { [alphaOrigin]: createServer('alpha', '10.0.0.1', 8080, alphaOrigin) },
+      alphaOrigin,
+      statusData({ servers: [details('beta', betaOrigin)] })
+    )
+    servers = mergeServerPollResult(servers, betaOrigin, statusData({ servers: [details('alpha', alphaOrigin)] }))
+
+    expect(serverTopologyMismatch(Object.values(servers))).toEqual([])
   })
 })

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -106,6 +106,11 @@ export interface ServerState {
   status: string
   assets: Array<AssetStatus>
   servers: Array<ServerDetails>
+  // Canonical origins advertised by this server's latest successful,
+  // authenticated poll. Undefined means no usable topology snapshot has been
+  // received yet. Connection failures and login expiry deliberately retain
+  // this snapshot so a transient poll failure cannot erase discovery state.
+  advertisedOrigins?: string[]
 }
 
 // Server names are operator-assigned display labels and are not guaranteed to
@@ -134,7 +139,8 @@ export const updateServerData = (server: ServerState, data: StatusData): ServerS
   userName: data.currentUser,
   csrfToken: data.csrfToken,
   assets: data.assets,
-  servers: data.servers
+  servers: data.servers,
+  advertisedOrigins: Array.from(new Set(data.servers.map((advertised) => canonicalServerOrigin(advertised.url))))
 })
 
 export const serverConnectFailed = (server: ServerState): ServerState => ({
@@ -150,8 +156,7 @@ export const serverUnauthenticated = (server: ServerState): ServerState => ({
   status: 'Login required',
   userName: undefined,
   csrfToken: undefined,
-  assets: [],
-  servers: []
+  assets: []
 })
 
 export const mergeServerPollResult = (currentServers: Record<string, ServerState>, serverKey: string, data: StatusData): Record<string, ServerState> => {
@@ -166,4 +171,48 @@ export const mergeServerPollResult = (currentServers: Record<string, ServerState
     nextServers[advertisedKey] = existing ? { ...existing, name: advertised.name, address: advertised.address, clientPort: advertised.clientPort, url: advertised.url } : advertised
   }
   return nextServers
+}
+
+// Keep only the part of the latest successful topology graph that remains
+// reachable from the page's direct origin. Traversing from the root prevents
+// an isolated cluster of stale snapshots from keeping itself alive forever.
+// Call this after every successful result in a poll batch has been merged so
+// reconciliation is independent of response order.
+export const reconcileServerTopology = (currentServers: Record<string, ServerState>, rootServerKey: string): Record<string, ServerState> => {
+  const canonicalRoot = canonicalServerOrigin(rootServerKey)
+  const retained = new Set<string>([canonicalRoot])
+  const pending = [canonicalRoot]
+
+  while (pending.length > 0) {
+    const serverKey = pending.pop()!
+    for (const advertisedOrigin of currentServers[serverKey]?.advertisedOrigins ?? []) {
+      if (retained.has(advertisedOrigin)) continue
+      retained.add(advertisedOrigin)
+      pending.push(advertisedOrigin)
+    }
+  }
+
+  return Object.fromEntries(Object.entries(currentServers).filter(([serverKey]) => retained.has(serverKey)))
+}
+
+export interface ServerTopologySnapshot {
+  serverName: string
+  origins: string[]
+}
+
+// ServerConfig describes peers, so a server normally omits itself from its
+// advertised list. Add the responding origin before comparing snapshots;
+// symmetric alpha->beta / beta->alpha configurations then describe the same
+// topology rather than producing a false warning.
+export const serverTopologyMismatch = (servers: ServerState[]): ServerTopologySnapshot[] => {
+  const snapshots = servers
+    .filter((server) => server.advertisedOrigins !== undefined)
+    .map((server) => ({
+      serverName: server.name,
+      origins: Array.from(new Set([server.url, ...server.advertisedOrigins!])).sort()
+    }))
+
+  if (snapshots.length < 2) return []
+  const reference = JSON.stringify(snapshots[0].origins)
+  return snapshots.some((snapshot) => JSON.stringify(snapshot.origins) !== reference) ? snapshots : []
 }


### PR DESCRIPTION
## Description

Retain authenticated topology snapshots across transient failures, prune peers no longer reachable from the direct origin, and remove their per-asset state so obsolete servers do not persist for the browser session.

## Summary by Sourcery

Reconcile discovered server topology so unreachable peers and their asset state are pruned while keeping the direct origin and retaining topology across transient failures.

New Features:
- Track canonical advertised origins from each server’s latest successful, authenticated poll.
- Provide topology reconciliation that keeps only servers reachable from the page’s direct origin.
- Expose topology mismatch reporting when servers advertise inconsistent peer sets.
- Add asset-side pruning to remove server entries and orphaned assets for origins no longer in the reconciled topology.

Bug Fixes:
- Avoid obsolete servers and their per-asset state persisting across the browser session after topology changes or transient poll failures.

Enhancements:
- Preserve server topology information across connection failures and authentication expiry instead of resetting discovery state.

Tests:
- Extend server and asset tests to cover topology reconciliation, mismatch detection, and pruning of obsolete server and asset entries.