### PR TITLE
fix: apply topology reconciliation to polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 - **One SMM configuration per asset** — a password-free audit and migration precheck identify legacy conflicts before the database enforces the optional one-to-one configuration contract. Unmigrated conflicting data returns an explicit `409` instead of selecting credentials by row order.
 - **Command acknowledgement history** — `AssetCommandAck` stores every acknowledgement with a database receipt time while the existing command columns remain the compatible latest-state view. The migration must land before the FSS writer begins inserting history rows.
 
+### Bug Fixes
+
+- **Reconciled peer topology** — successful authenticated polls now replace each server's discovery snapshot and prune obsolete peer origins and their asset state. Failed polls preserve the last successful topology, while conflicting retained snapshots remain visible in an operator warning.
+
 ## 1.0.0 — 2026-05-17
 
 First production release.

--- a/frontend/fss-main-page.test.tsx
+++ b/frontend/fss-main-page.test.tsx
@@ -240,4 +240,25 @@ describe('FSS server redundancy status', () => {
 
     expect(screen.getByRole('status').textContent).toBe('Systems: Critical — Redundancy lost: 0 FSS servers reachable; 2 required')
   })
+
+  it('surfaces topology disagreement with each retained server snapshot', () => {
+    const alpha = { ...makeServer('alpha'), advertisedOrigins: ['https://gamma.example'] }
+    const gamma = { ...makeServer('gamma'), advertisedOrigins: ['https://alpha.example', 'https://beta.example'] }
+
+    render(<FSSServerBar knownServers={[alpha, gamma]} />)
+
+    const warning = screen.getByRole('alert')
+    expect(warning.textContent).toContain('Server topology mismatch')
+    expect(warning.textContent).toContain('alpha: https://alpha.example, https://gamma.example')
+    expect(warning.textContent).toContain('gamma: https://alpha.example, https://beta.example, https://gamma.example')
+  })
+
+  it('does not warn for symmetric peer snapshots', () => {
+    const alpha = { ...makeServer('alpha'), advertisedOrigins: ['https://beta.example'] }
+    const beta = { ...makeServer('beta'), advertisedOrigins: ['https://alpha.example'] }
+
+    render(<FSSServerBar knownServers={[alpha, beta]} />)
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
 })

--- a/frontend/fss-main-page.tsx
+++ b/frontend/fss-main-page.tsx
@@ -7,9 +7,21 @@ import {
   CommandSubmissionGuard,
   assetCommandAvailability,
   createAssetController,
-  mergeServerAssets
+  mergeServerAssets,
+  pruneAssetServers
 } from './asset'
-import { ServerState, canonicalServerOrigin, createServer, getServerURL, serverConnectFailed, serverUnauthenticated, AssetPositionData, mergeServerPollResult } from './server'
+import {
+  ServerState,
+  canonicalServerOrigin,
+  createServer,
+  getServerURL,
+  serverConnectFailed,
+  serverUnauthenticated,
+  AssetPositionData,
+  mergeServerPollResult,
+  reconcileServerTopology,
+  serverTopologyMismatch
+} from './server'
 import {
   assetPositionTimeWarn,
   assetPositionTimeOld,
@@ -527,6 +539,7 @@ export function FSSServerBar(props: FSSServerBarProps) {
   const reachableServers = knownServers.filter((server) => server.connected).length
   const redundancyLost = reachableServers < 2
   const serverNoun = reachableServers === 1 ? 'server' : 'servers'
+  const topologyMismatch = serverTopologyMismatch(knownServers)
   return (
     <div className="bar-server">
       <div className={`alert ${redundancyLost ? 'alert-danger' : 'alert-success'} system-status`} role="status">
@@ -534,6 +547,18 @@ export function FSSServerBar(props: FSSServerBarProps) {
         {' — '}
         {redundancyLost ? `Redundancy lost: ${reachableServers} FSS ${serverNoun} reachable; 2 required` : `${reachableServers} FSS ${serverNoun} reachable`}
       </div>
+      {topologyMismatch.length > 0 && (
+        <div className="alert alert-warning topology-mismatch" role="alert">
+          <strong>Server topology mismatch</strong> — peers advertise different FSS server sets.
+          <ul>
+            {topologyMismatch.map((snapshot) => (
+              <li key={snapshot.serverOrigin}>
+                {snapshot.serverName}: {snapshot.origins.join(', ')}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       {knownServers.map((server) => (
         <FSSServer key={server.url} server={server} />
       ))}
@@ -542,8 +567,9 @@ export function FSSServerBar(props: FSSServerBarProps) {
 }
 
 export const FSSMainPage: React.FC = () => {
+  const directServerKey = canonicalServerOrigin(window.location.origin)
   const [knownServers, setKnownServers] = useState<Record<string, ServerState>>({
-    [canonicalServerOrigin(window.location.origin)]: createServer('direct', '127.0.0.1', 0, window.location.origin)
+    [directServerKey]: createServer('direct', '127.0.0.1', 0, window.location.origin)
   })
   const [knownAssets, setKnownAssets] = useState<Record<string, AssetState>>({})
   const [lastError, setLastError] = useState<CommandFailure | null>(null)
@@ -594,6 +620,9 @@ export const FSSMainPage: React.FC = () => {
     let currentAssets = { ...knownAssetsRef.current }
 
     for (const { serverKey, data, unauthenticated } of results) {
+      // A newer cycle may already have pruned a server while this superseded
+      // request was resolving. Its stale result must not resurrect the origin.
+      if (!currentServers[serverKey]) continue
       if (data === null) {
         if (unauthenticated) {
           currentServers = { ...currentServers, [serverKey]: serverUnauthenticated(currentServers[serverKey]) }
@@ -605,11 +634,14 @@ export const FSSMainPage: React.FC = () => {
       }
     }
 
+    currentServers = reconcileServerTopology(currentServers, directServerKey)
+
     for (const { serverKey, data } of results) {
-      if (data !== null) {
+      if (data !== null && currentServers[serverKey]) {
         currentAssets = mergeServerAssets(currentAssets, serverKey, currentServers[serverKey].name, data.assets, data.server_now)
       }
     }
+    currentAssets = pruneAssetServers(currentAssets, new Set(Object.keys(currentServers)))
 
     setKnownServers(currentServers)
     setKnownAssets(currentAssets)

--- a/frontend/fssweb.css
+++ b/frontend/fssweb.css
@@ -12,6 +12,15 @@ div.bar-server {
   margin: 0 10px 10px;
 }
 
+.topology-mismatch {
+  margin: 0 10px 10px;
+  text-align: left;
+}
+
+.topology-mismatch ul {
+  margin-bottom: 0;
+}
+
 div.bar-assets {
   width: 100%;
   margin: 0 auto;

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -197,6 +197,7 @@ export const reconcileServerTopology = (currentServers: Record<string, ServerSta
 
 export interface ServerTopologySnapshot {
   serverName: string
+  serverOrigin: string
   origins: string[]
 }
 
@@ -209,6 +210,7 @@ export const serverTopologyMismatch = (servers: ServerState[]): ServerTopologySn
     .filter((server) => server.advertisedOrigins !== undefined)
     .map((server) => ({
       serverName: server.name,
+      serverOrigin: server.url,
       origins: Array.from(new Set([server.url, ...server.advertisedOrigins!])).sort()
     }))
 


### PR DESCRIPTION
## Description

Reconcile the complete poll batch from the permanent direct origin, prune removed origins from asset state, and warn operators when retained servers advertise conflicting topologies.

## Summary by Sourcery

Reconcile server topology during polling and surface mismatched peer snapshots to operators.

Bug Fixes:
- Prevent stale poll responses from resurrecting previously pruned servers.
- Ensure asset state is pruned for servers removed from the reconciled topology.

Enhancements:
- Display a warning banner listing servers that advertise conflicting FSS peer topologies.
- Add styling for the topology mismatch warning banner in the server status bar.

Documentation:
- Document reconciled peer topology behavior and operator-visible warning in the changelog.

Tests:
- Add tests covering topology mismatch warnings and symmetric peer snapshots for the server bar.